### PR TITLE
fix: update model builder to handle array properties

### DIFF
--- a/tests/unit/test_component_naming.py
+++ b/tests/unit/test_component_naming.py
@@ -499,6 +499,97 @@ class TestStandardNamingConventions(BaseRuleTest):
 		)
 
 
+class TestNamePatternArrayProperties(BaseRuleTest):
+	"""Test that array properties are treated as a single property, not multiple properties."""
+
+	def test_array_property_validated_once(self):
+		"""Array property should be validated once for the base name, not once per element."""
+		rule_config = get_test_config(
+			"NamePatternRule",
+			target_node_types=["property"],
+			convention="camelCase",
+			severity="error"
+		)
+
+		# Create a view with an array property that violates camelCase
+		view_data = {
+			"custom": {
+				"MyArrayProperty": ["item1", "item2", "item3"]  # PascalCase - should fail
+			},
+			"params": {},
+			"props": {},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+
+		# Write test view file
+		import json
+		import tempfile
+		from pathlib import Path
+		with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+			json.dump(view_data, f)
+			view_file = Path(f.name)
+
+		try:
+			# Run the linter
+			self.run_lint_on_file(view_file, rule_config)
+			errors = self.get_errors_for_rule("NamePatternRule")
+
+			# Should have exactly 1 error for MyArrayProperty, not 3 (one per element)
+			self.assertEqual(len(errors), 1,
+				f"Expected 1 error for array property, got {len(errors)}: {errors}")
+
+			# Error should reference the base property name, not an indexed element
+			self.assertIn("MyArrayProperty", errors[0])
+			self.assertNotIn("[0]", errors[0], "Error should not reference array index [0]")
+			self.assertNotIn("[1]", errors[0], "Error should not reference array index [1]")
+			self.assertNotIn("[2]", errors[0], "Error should not reference array index [2]")
+		finally:
+			view_file.unlink()
+
+	def test_array_property_with_valid_name(self):
+		"""Array property with valid name should pass validation."""
+		rule_config = get_test_config(
+			"NamePatternRule",
+			target_node_types=["property"],
+			convention="camelCase",
+			severity="error"
+		)
+
+		# Create a view with an array property that follows camelCase
+		view_data = {
+			"custom": {
+				"myArrayProperty": ["item1", "item2", "item3"]  # camelCase - should pass
+			},
+			"params": {},
+			"props": {},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+
+		# Write test view file
+		import json
+		import tempfile
+		from pathlib import Path
+		with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+			json.dump(view_data, f)
+			view_file = Path(f.name)
+
+		try:
+			# Array property with valid name should pass
+			self.assert_rule_passes(view_file, rule_config, "NamePatternRule")
+		finally:
+			view_file.unlink()
+
+
 class TestNamePatternCSSProperties(BaseRuleTest):
 	"""Test that CSS properties in style and elementStyle are not flagged as violations."""
 


### PR DESCRIPTION
## Description

Rebased version of PR #14 from @ia-eknorr's fork to resolve merge conflicts.

Fixes #13

## Changes

**Array Property Handling** (`src/ignition_lint/model/builder.py`):
- Added `_extract_property_name()` method to strip array indices from property paths
  - Example: `custom.myList[0]` → `myList`
- Modified `_collect_properties()` to track processed properties and avoid duplicates
  - Array properties like `["item1", "item2", "item3"]` now validate once instead of 3 times
  - Uses `base_path` (without array indices) to deduplicate
  - Uses regex to strip `[\d+]` patterns from paths

**Test Coverage** (`tests/unit/test_component_naming.py`):
- Added `TestNamePatternArrayProperties` test class
  - Tests array properties validate once, not per element
  - Verifies error messages don't reference array indices `[0]`, `[1]`, `[2]`
  - Tests both failing and passing cases

**Debug Files**:
- Regenerated all debug files to reflect array property deduplication
- Properties now show base path without array indices

## Testing

✅ All 100 unit tests pass
✅ Array properties validated once instead of per-element
✅ Debug files regenerated and golden file tests pass

## Notes

This PR replaces PR #14 which had merge conflicts due to CSS property changes already being merged into dev. The CSS-related changes were dropped during rebase, keeping only the array property handling improvements.

Original author: @ia-eknorr