### PR TITLE
fix: Add --ignore-warnings to CLI functionality test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Test CLI functionality
         run: |
           poetry run python -m ignition_lint --help
-          poetry run python -m ignition_lint --config .github/workflows/.ignition-lint-ci.json --files tests/cases/PascalCase/view.json
+          poetry run python -m ignition_lint --config .github/workflows/.ignition-lint-ci.json --files tests/cases/PascalCase/view.json --ignore-warnings
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the failing "Test CLI functionality" GitHub Action by adding the `--ignore-warnings` flag to the CI test command.

## Problem

The CLI functionality test runs against `tests/cases/PascalCase/view.json`, which intentionally contains naming violations that trigger warnings. The tool was working correctly and finding 5 warnings as expected, but the CI test was failing because the CLI exits with code 1 when issues are found.

## Solution

Added the `--ignore-warnings` flag to the test command:
```bash
poetry run python -m ignition_lint --config .github/workflows/.ignition-lint-ci.json --files tests/cases/PascalCase/view.json --ignore-warnings
```

This allows the test to verify the CLI works correctly without failing on expected warnings. The test is checking CLI functionality, not that the test files are clean.

## Testing

- Pre-commit hooks passed
- The `--ignore-warnings` flag causes the CLI to exit with code 0 even when warnings are found

## Related

- Completes the fix for PR #26 (dev → main for v0.2.6 release)
- Previous fix in PR #28 added the `--files` flag but didn't account for expected warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)