### PR TITLE
v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.10] - 2026-01-29
+
+### Added
+- NamePatternRule now skips props.aspectRatio properties to prevent false positives on coordinate containers [eabbb41]
+
 ## [0.2.9] - 2026-01-27
 
 ### Added
@@ -156,7 +161,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Initial tracked release
 
-[Unreleased]: https://github.com/bw-design-group/ignition-lint/compare/v0.2.9...HEAD
+[Unreleased]: https://github.com/bw-design-group/ignition-lint/compare/v0.2.10...HEAD
+[0.2.10]: https://github.com/bw-design-group/ignition-lint/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/bw-design-group/ignition-lint/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/bw-design-group/ignition-lint/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/bw-design-group/ignition-lint/compare/v0.2.6...v0.2.7

--- a/rule_config.json
+++ b/rule_config.json
@@ -77,7 +77,7 @@
       "component": "User-defined component names (PascalCase)",
       "property": "User-defined custom property names (camelCase)",
       "message_handler": "User-defined message type names (kebab-case)",
-      "custom_method": "User-defined custom method names (snake_case)",
+      "custom_method": "User-defined custom method names (snake_case)"
     },
     "PylintScriptRule_config": {
       "pylintrc": "Path to custom pylintrc file. Defaults to .config/ignition.pylintrc if not specified.",

--- a/src/ignition_lint/rules/naming/name_pattern.py
+++ b/src/ignition_lint/rules/naming/name_pattern.py
@@ -346,11 +346,8 @@ class NamePatternRule(LintingRule):
 		#   root.Line1.props.elements[0].d -> SVG path data (in array)
 		#   custom.myProperty -> NOT skipped
 		skip_containers = (
-			'.style.',
-			'.elementStyle.',
-			'.textStyle.',
-			'.instanceStyle.',
-			'.position.',
+			'.style.', '.elementStyle.', '.textStyle.', '.instanceStyle.', '.position.',
+			'.props.aspectRatio'
 		)
 
 		# Check standard skip containers


### PR DESCRIPTION
NamePatternRule now skips props.aspectRatio properties to prevent false positives on coordinate containers [eabbb41]
https://github.com/bw-design-group/ignition-lint/pull/41