### PR TITLE
Auto-fix trailing whitespace (C0303) in embedded scripts

### DIFF
--- a/.config/.pylintrc
+++ b/.config/.pylintrc
@@ -108,7 +108,8 @@ source-roots=
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
+# Note: suggestion-mode was removed in pylint 3.x (behavior is now always on)
+#suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ bin/
 # Build artifacts
 dist/
 
+# Jython cache
+**/.jython_cache/
+
 # Ignition specific content
 .resources/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Auto-fix for trailing whitespace (C0303) in PylintScriptRule via `--fix` flag
+- PylintScriptRule now uses FixableMixin so the existing fix infrastructure discovers it automatically
+
 ## [0.4.1] - 2026-02-20
 
 ### Changed

--- a/src/ignition_lint/rules/scripts/lint_script.py
+++ b/src/ignition_lint/rules/scripts/lint_script.py
@@ -17,8 +17,9 @@ from io import StringIO
 from pylint import lint
 from pylint.reporters.text import TextReporter
 
-from ..common import ScriptRule
-from ...model.node_types import ScriptNode
+from ..common import ScriptRule, FixableMixin
+from ...common.fix_operations import Fix, FixOperation, FixOperationType
+from ...model.node_types import ScriptNode, NodeType
 
 
 @dataclass
@@ -36,11 +37,11 @@ class PylintViolation:
 	severity: str = ''  # Severity level ("error" or "warning") - set by rule
 
 
-class PylintScriptRule(ScriptRule):
+class PylintScriptRule(FixableMixin, ScriptRule):
 	"""Rule to run pylint on all script types using the simplified interface."""
 
 	def __init__(
-		self, severity="error", pylintrc=None, debug=False, batch_mode=False, debug_dir=None,
+		self, severity="error", pylintrc=None, debug=False, batch_mode=False, *, debug_dir=None,
 		category_mapping=None
 	):
 		super().__init__(severity=severity)  # Targets all script types by default
@@ -84,19 +85,17 @@ class PylintScriptRule(ScriptRule):
 			if os.path.isabs(pylintrc):
 				if os.path.exists(pylintrc):
 					return pylintrc
-				else:
-					print(f"⚠️  Warning: Specified pylintrc not found: {pylintrc}")
-					print(f"   Falling back to standard location search...")
+				print(f"⚠️  Warning: Specified pylintrc not found: {pylintrc}")
+				print("   Falling back to standard location search...")
 			else:
 				# Try relative to current working directory
 				abs_path = os.path.join(os.getcwd(), pylintrc)
 				if os.path.exists(abs_path):
 					return abs_path
-				else:
-					print(f"⚠️  Warning: Specified pylintrc not found: {pylintrc}")
-					print(f"   Tried: {abs_path}")
-					print(f"   Current directory: {os.getcwd()}")
-					print("   Falling back to standard location search...")
+				print(f"⚠️  Warning: Specified pylintrc not found: {pylintrc}")
+				print(f"   Tried: {abs_path}")
+				print(f"   Current directory: {os.getcwd()}")
+				print("   Falling back to standard location search...")
 
 		# Fall back to standard location: .config/ignition.pylintrc
 		# First, search from current directory up to find the project root (user's custom config)
@@ -139,6 +138,7 @@ class PylintScriptRule(ScriptRule):
 			self.warnings = []
 			self.pylint_violations = []
 			self.collected_scripts = {}
+			self.reset_fixes()
 		# In batch mode: don't reset anything - accumulate across all files
 
 		# Filter nodes that this rule applies to
@@ -181,6 +181,80 @@ class PylintScriptRule(ScriptRule):
 		if "::" in composite_key:
 			return composite_key.split("::", 1)[1]
 		return composite_key
+
+	@staticmethod
+	def _strip_trailing_whitespace(script_content: str) -> str:
+		"""Strip trailing whitespace from each line of a script."""
+		return '\n'.join(line.rstrip() for line in script_content.split('\n'))
+
+	def _get_script_content_path(self, node: ScriptNode) -> Optional[str]:
+		"""
+		Map a script node to its JSON path for the script content value.
+
+		Returns the JSON dict access path (list), or None if not resolvable.
+		"""
+		if not self._path_translator:
+			return None
+
+		# Determine the suffix based on node type
+		suffix_candidates = []
+		if node.node_type == NodeType.TRANSFORM:
+			suffix_candidates = ['.code']
+		elif node.node_type == NodeType.EVENT_HANDLER:
+			suffix_candidates = ['.config.script', '.script']
+		elif node.node_type in (NodeType.MESSAGE_HANDLER, NodeType.CUSTOM_METHOD):
+			suffix_candidates = ['.script']
+
+		for suffix in suffix_candidates:
+			model_path = f"{node.path}{suffix}"
+			json_path = self._path_translator.model_path_to_json_path(model_path)
+			if json_path is not None:
+				return json_path
+
+		return None
+
+	def _generate_trailing_whitespace_fixes(self, scripts: Dict[str, ScriptNode]):
+		"""Generate Fix objects for scripts that have C0303 (trailing-whitespace) violations."""
+		if not self.has_fix_context or self.batch_mode:
+			return
+
+		# Collect composite keys that have C0303 violations
+		affected_keys = {v.path for v in self.pylint_violations if v.code == 'C0303'}
+		if not affected_keys:
+			return
+
+		for composite_key in affected_keys:
+			if composite_key not in scripts:
+				continue
+
+			node = scripts[composite_key]
+			original = node.script
+			stripped = self._strip_trailing_whitespace(original)
+
+			if stripped == original:
+				continue
+
+			json_path = self._get_script_content_path(node)
+			if json_path is None:
+				continue
+
+			display_path = self._format_script_path(composite_key)
+			fix = Fix(
+				rule_name='PylintScriptRule',
+				violation_message=f"{display_path}: Trailing whitespace (C0303)",
+				description=f"Remove trailing whitespace from script at {display_path}",
+				operations=[
+					FixOperation(
+						operation=FixOperationType.SET_VALUE,
+						json_path=json_path,
+						old_value=original,
+						new_value=stripped,
+						description="Strip trailing whitespace from all lines",
+					)
+				],
+				is_safe=True,
+			)
+			self.add_fix(fix)
 
 	def get_category_grouped_violations(self) -> Dict[str, Dict[str, List[str]]]:
 		"""
@@ -306,6 +380,9 @@ class PylintScriptRule(ScriptRule):
 		# Note: _run_pylint_batch populates self.pylint_violations with structured data
 		_path_to_issues = self._run_pylint_batch(scripts)
 
+		# Generate auto-fixes for trailing whitespace violations
+		self._generate_trailing_whitespace_fixes(scripts)
+
 		# Add placeholder violations for counting purposes (won't be displayed due to custom formatting)
 		# This ensures file counts are correct
 		for violation in self.pylint_violations:
@@ -372,8 +449,7 @@ class PylintScriptRule(ScriptRule):
 		if self.debug_dir_config:
 			if os.path.isabs(self.debug_dir_config):
 				return self.debug_dir_config
-			else:
-				return os.path.join(cwd, self.debug_dir_config)
+			return os.path.join(cwd, self.debug_dir_config)
 
 		# Priority 2: Try to detect if we're in a test environment and use tests/debug
 		current_path = cwd
@@ -381,7 +457,7 @@ class PylintScriptRule(ScriptRule):
 			if os.path.basename(current_path) == 'tests':
 				# We're in tests directory
 				return os.path.join(current_path, "debug")
-			elif os.path.exists(os.path.join(current_path, 'tests')):
+			if os.path.exists(os.path.join(current_path, 'tests')):
 				# Tests directory exists in current path
 				return os.path.join(current_path, "tests", "debug")
 			current_path = os.path.dirname(current_path)

--- a/tests/unit/test_pylint_trailing_whitespace_fix.py
+++ b/tests/unit/test_pylint_trailing_whitespace_fix.py
@@ -1,0 +1,329 @@
+# pylint: disable=import-error,wrong-import-position,protected-access
+"""
+Unit tests for PylintScriptRule trailing-whitespace (C0303) auto-fix.
+
+Tests cover:
+- Static helper strips trailing whitespace
+- No fixes generated when fix mode is off
+- Fix generation for scripts with trailing whitespace
+- One fix per script (not per C0303 line)
+- End-to-end: apply fix then re-lint to confirm C0303 gone
+- process_nodes resets fixes in non-batch mode
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from collections import OrderedDict
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from src.ignition_lint.rules.scripts.lint_script import PylintScriptRule
+from src.ignition_lint.common.fix_operations import FixOperationType
+from src.ignition_lint.common.path_translator import PathTranslator
+from src.ignition_lint.common.flatten_json import flatten_json
+from src.ignition_lint.common.fix_engine import FixEngine
+from src.ignition_lint.linter import LintEngine
+
+
+def _make_pylintrc():
+	"""Create a temporary pylintrc that only enables trailing-whitespace."""
+	tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.pylintrc', delete=False, encoding='utf-8')
+	tmp.write(
+		"[MAIN]\n"
+		"load-plugins=\n"
+		"\n"
+		"[MESSAGES CONTROL]\n"
+		"disable=all\n"
+		"enable=trailing-whitespace\n"
+		"\n"
+		"[FORMAT]\n"
+		"indent-string='\\t'\n"
+		"max-line-length=200\n"
+	)
+	tmp.close()
+	return tmp.name
+
+
+def _make_view_with_event_handler(script_content):
+	"""Build a minimal view.json with a single event handler script."""
+	return OrderedDict([
+		(
+			'root',
+			OrderedDict([
+				(
+					'children', [
+						OrderedDict([
+							(
+								'events',
+								OrderedDict([
+									(
+										'component',
+										OrderedDict([
+											(
+												'onActionPerformed',
+												OrderedDict([
+													(
+														'config',
+														OrderedDict([
+															(
+																'script',
+																script_content
+															),
+														])
+													),
+													('scope', 'G'),
+													(
+														'type',
+														'script'
+													),
+												])
+											),
+										])
+									),
+								])
+							),
+							('meta', OrderedDict([('name', 'TestButton')])),
+							('props', OrderedDict()),
+							('type', 'ia.input.button'),
+						]),
+					]
+				),
+				('meta', OrderedDict([('name', 'root')])),
+				('props', OrderedDict()),
+				('type', 'ia.container.flex'),
+			])
+		),
+	])
+
+
+class TestStripTrailingWhitespace(unittest.TestCase):
+	"""Test the static _strip_trailing_whitespace helper."""
+
+	def test_strips_spaces_and_tabs(self):
+		"""Should strip trailing spaces and tabs from each line."""
+		script = "\tx = 1   \n\ty = 2\t\n\tz = 3"
+		result = PylintScriptRule._strip_trailing_whitespace(script)
+		self.assertEqual(result, "\tx = 1\n\ty = 2\n\tz = 3")
+
+	def test_preserves_clean_script(self):
+		"""Should return identical string when no trailing whitespace exists."""
+		script = "\tx = 1\n\ty = 2"
+		result = PylintScriptRule._strip_trailing_whitespace(script)
+		self.assertEqual(result, script)
+
+	def test_handles_empty_string(self):
+		"""Should handle empty string without error."""
+		self.assertEqual(PylintScriptRule._strip_trailing_whitespace(""), "")
+
+	def test_handles_blank_lines(self):
+		"""Should strip whitespace-only lines to empty lines."""
+		script = "\tx = 1\n   \n\ty = 2"
+		result = PylintScriptRule._strip_trailing_whitespace(script)
+		self.assertEqual(result, "\tx = 1\n\n\ty = 2")
+
+
+class TestNoFixWithoutContext(unittest.TestCase):
+	"""Fixes should not be generated when fix mode is off."""
+
+	@classmethod
+	def setUpClass(cls):
+		cls.pylintrc = _make_pylintrc()
+
+	@classmethod
+	def tearDownClass(cls):
+		os.unlink(cls.pylintrc)
+
+	def test_no_fix_without_fix_context(self):
+		"""No Fix objects when path_translator / json_context are not set."""
+		script = "\tx = 1   \n\ty = 2\t"
+		json_data = _make_view_with_event_handler(script)
+		flattened = flatten_json(json_data)
+
+		rule = PylintScriptRule(pylintrc=self.pylintrc)
+		engine = LintEngine([rule])
+
+		# Process WITHOUT fix context
+		results = engine.process(flattened, source_file_path='test.json')
+
+		self.assertEqual(len(results.fixes), 0)
+
+
+class TestGeneratesFixForTrailingWhitespace(unittest.TestCase):
+	"""Fix generation for scripts with trailing whitespace."""
+
+	@classmethod
+	def setUpClass(cls):
+		cls.pylintrc = _make_pylintrc()
+
+	@classmethod
+	def tearDownClass(cls):
+		os.unlink(cls.pylintrc)
+
+	def test_generates_fix(self):
+		"""Should produce a Fix with is_safe=True and SET_VALUE operation."""
+		script = "\tx = 1   \n\ty = 2\t"
+		json_data = _make_view_with_event_handler(script)
+		flattened = flatten_json(json_data)
+		translator = PathTranslator(json_data)
+
+		rule = PylintScriptRule(pylintrc=self.pylintrc)
+		engine = LintEngine([rule])
+
+		results = engine.process(
+			flattened,
+			source_file_path='test.json',
+			json_data=json_data,
+			path_translator=translator,
+		)
+
+		self.assertGreater(len(results.fixes), 0)
+		fix = results.fixes[0]
+		self.assertTrue(fix.is_safe)
+		self.assertEqual(fix.rule_name, 'PylintScriptRule')
+		self.assertEqual(len(fix.operations), 1)
+		op = fix.operations[0]
+		self.assertEqual(op.operation, FixOperationType.SET_VALUE)
+		self.assertEqual(op.old_value, script)
+		# New value should have whitespace stripped
+		self.assertEqual(op.new_value, "\tx = 1\n\ty = 2")
+
+
+class TestOneFixPerScript(unittest.TestCase):
+	"""Multiple C0303 lines in one script should produce exactly one Fix."""
+
+	@classmethod
+	def setUpClass(cls):
+		cls.pylintrc = _make_pylintrc()
+
+	@classmethod
+	def tearDownClass(cls):
+		os.unlink(cls.pylintrc)
+
+	def test_one_fix_per_script(self):
+		"""Multiple trailing-whitespace lines → one Fix, not N fixes."""
+		script = "\tx = 1   \n\ty = 2   \n\tz = 3   "
+		json_data = _make_view_with_event_handler(script)
+		flattened = flatten_json(json_data)
+		translator = PathTranslator(json_data)
+
+		rule = PylintScriptRule(pylintrc=self.pylintrc)
+		engine = LintEngine([rule])
+
+		results = engine.process(
+			flattened,
+			source_file_path='test.json',
+			json_data=json_data,
+			path_translator=translator,
+		)
+
+		# Exactly one fix, even though 3 lines have C0303
+		pylint_fixes = [f for f in results.fixes if f.rule_name == 'PylintScriptRule']
+		self.assertEqual(len(pylint_fixes), 1)
+
+
+class TestFixApplicationEndToEnd(unittest.TestCase):
+	"""Apply fix then re-lint: C0303 should be gone."""
+
+	@classmethod
+	def setUpClass(cls):
+		cls.pylintrc = _make_pylintrc()
+
+	@classmethod
+	def tearDownClass(cls):
+		os.unlink(cls.pylintrc)
+
+	def test_fix_then_relint(self):
+		"""After applying the fix, re-linting should find zero C0303 violations."""
+		script = "\tx = 1   \n\ty = 2\t"
+		json_data = _make_view_with_event_handler(script)
+		flattened = flatten_json(json_data)
+		translator = PathTranslator(json_data)
+
+		rule = PylintScriptRule(pylintrc=self.pylintrc)
+		engine = LintEngine([rule])
+
+		# First pass: detect and fix
+		results = engine.process(
+			flattened,
+			source_file_path='test.json',
+			json_data=json_data,
+			path_translator=translator,
+		)
+		self.assertGreater(len(results.fixes), 0)
+
+		# Apply fixes to json_data
+		fix_engine = FixEngine(translator)
+		fix_result = fix_engine.apply_fixes(results.fixes, safe_only=True)
+		self.assertGreater(fix_result.applied_count, 0)
+
+		# Re-flatten and re-lint
+		flattened2 = flatten_json(json_data)
+		translator2 = PathTranslator(json_data)
+		rule2 = PylintScriptRule(pylintrc=self.pylintrc)
+		engine2 = LintEngine([rule2])
+
+		results2 = engine2.process(
+			flattened2,
+			source_file_path='test.json',
+			json_data=json_data,
+			path_translator=translator2,
+		)
+
+		# No C0303 violations should remain
+		c0303 = [v for v in rule2.pylint_violations if v.code == 'C0303']
+		self.assertEqual(len(c0303), 0)
+		self.assertEqual(len(results2.fixes), 0)
+
+
+class TestProcessNodesResetsFixes(unittest.TestCase):
+	"""Non-batch mode should clear fixes between files."""
+
+	@classmethod
+	def setUpClass(cls):
+		cls.pylintrc = _make_pylintrc()
+
+	@classmethod
+	def tearDownClass(cls):
+		os.unlink(cls.pylintrc)
+
+	def test_resets_between_files(self):
+		"""Fixes from file 1 should not leak into file 2 results."""
+		script = "\tx = 1   "
+		json_data = _make_view_with_event_handler(script)
+		flattened = flatten_json(json_data)
+		translator = PathTranslator(json_data)
+
+		rule = PylintScriptRule(pylintrc=self.pylintrc)
+		engine = LintEngine([rule])
+
+		# Process first file (produces fixes)
+		results1 = engine.process(
+			flattened,
+			source_file_path='file1.json',
+			json_data=json_data,
+			path_translator=translator,
+		)
+		fix_count_1 = len(results1.fixes)
+		self.assertGreater(fix_count_1, 0)
+
+		# Process a clean file (no trailing whitespace)
+		clean_script = "\tx = 1\n\ty = 2"
+		clean_json = _make_view_with_event_handler(clean_script)
+		clean_flat = flatten_json(clean_json)
+		clean_translator = PathTranslator(clean_json)
+
+		results2 = engine.process(
+			clean_flat,
+			source_file_path='file2.json',
+			json_data=clean_json,
+			path_translator=clean_translator,
+		)
+
+		# Second file should have zero fixes
+		self.assertEqual(len(results2.fixes), 0)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Summary

Add `FixableMixin` to `PylintScriptRule` so `--fix` discovers and applies trailing whitespace (C0303) fixes automatically. One `Fix` per affected script with `SET_VALUE` operation — strips trailing spaces/tabs from each line.

Trailing whitespace (C0303) is the largest source of pylint warnings in embedded Ignition scripts — ~77% of findings in one project. Standard tools can't fix these because scripts are embedded as JSON string values. The `--fix` infrastructure already exists; this change makes PylintScriptRule participate in it.

---

## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] Feature (adds new functionality)
- [x] Chore (cleanup, refactoring, or maintenance)
- [ ] Documentation update

**Impact:**

- [ ] Breaking change (would cause existing functionality not to work as expected)
- [x] Non-breaking change
- [ ] Requires documentation update

---

## Change Log

- **Added** auto-fix for trailing whitespace (C0303) in PylintScriptRule via `--fix` flag
- **Added** PylintScriptRule now uses FixableMixin so the existing fix infrastructure discovers it automatically
- **Fixed** pre-existing pylint issues in lint_script.py (no-else-return, too-many-positional-arguments, f-string-without-interpolation)
- **Fixed** deprecated `suggestion-mode` option in `.pylintrc` that broke pre-commit hook

---

## Target Version

v0.5.0

---

## Related Issues

<!-- No related issues -->

### Screenshots

N/A

## Review and Testing Notes

- 9 unit tests in `tests/unit/test_pylint_trailing_whitespace_fix.py` covering: static helper, no-fix-without-context, fix generation, one-fix-per-script, end-to-end apply+re-lint, reset between files
- Smoke tested against publicdemo-vertical-datacenter: 163 fixes applied across 61 files, 0 C0303 remaining after fix
- All existing unit tests pass
- pylint 10.00/10 on lint_script.py (was 9.83)
- The `*` keyword-only separator added to `__init__` for `debug_dir` and `category_mapping` params — all existing callers use keyword args so this is non-breaking