### PR TITLE
fix: clear stale aggregated summary between runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Auto-fix for trailing whitespace (C0303) in PylintScriptRule via `--fix` flag
-- PylintScriptRule now uses FixableMixin so the existing fix infrastructure discovers it automatically
+- Auto-fix for trailing whitespace (C0303) in PylintScriptRule via `--fix` flag [d775d45]
+- PylintScriptRule now uses FixableMixin so the existing fix infrastructure discovers it automatically [d775d45]
+
+### Changed
+- Gitignore jython cache directories [67e8ede]
+- Each pre-commit batch invocation now reports its own honest totals; removed the terminal-summary override that aggregated escalating totals across batches (the `_AGGREGATED_SUMMARY.txt` file is still written when batch files exist) [dacf480]
+
+### Fixed
+- Stale `_AGGREGATED_SUMMARY.txt` from a previous run no longer pollutes a later passing run's reported totals; cleanup now removes stale summary files (≥5s old) and the aggregator no longer reads existing summaries on non-batch paths [dacf480]
 
 ## [0.4.1] - 2026-02-20
 

--- a/src/ignition_lint/cli.py
+++ b/src/ignition_lint/cli.py
@@ -174,10 +174,6 @@ def cleanup_old_batch_files(output_path: Path) -> None:
 	# Check batch files (e.g., results_pid*_batch*.txt)
 	pattern = f"{base_name}*batch*.txt"
 	for file_path in output_path.parent.glob(pattern):
-		# Skip aggregated summary files
-		if 'AGGREGATED_SUMMARY' in file_path.name:
-			continue
-
 		# Extract PID from filename (e.g., results_pid12345_batch1.txt)
 		if f'_pid{current_pid}_' in file_path.name:
 			# Same PID as current run - skip
@@ -195,6 +191,19 @@ def cleanup_old_batch_files(output_path: Path) -> None:
 
 		# Old batch file from previous run - mark for deletion
 		files_to_clean.append(file_path)
+
+	# Check aggregated summary file (e.g., results_AGGREGATED_SUMMARY.txt)
+	# These have no PID in the name, so age-based check only.
+	# Stale summaries pollute new runs by reporting old totals (see
+	# aggregate_batch_results: it reads an existing summary for non-batch paths).
+	summary_file = output_path.parent / f"{base_name}_AGGREGATED_SUMMARY.txt"
+	if summary_file.exists():
+		try:
+			file_age = current_time - summary_file.stat().st_mtime
+			if file_age >= 5:
+				files_to_clean.append(summary_file)
+		except OSError:
+			pass
 
 	# Clean up old files
 	if files_to_clean:
@@ -961,35 +970,10 @@ def aggregate_batch_results(results_path: Path) -> Optional[Dict[str, int]]:
 	else:
 		base_name = results_path.stem
 
-	# Check if this is a batched result (has _pid and _batch in name)
+	# Only aggregate when this invocation produced a batch file (has _pid and _batch).
+	# A non-batch path means this is a standalone or first-batch run; its own totals
+	# are already correct and the caller no longer overrides them from the summary.
 	is_batch_file = '_pid' in results_path.name and '_batch' in results_path.name
-
-	# If not a batch file, check for existing aggregated summary
-	summary_path = parent_dir / f"{base_name}_AGGREGATED_SUMMARY.txt"
-	if not is_batch_file and summary_path.exists():
-		# Read and return totals from existing aggregated summary
-		# (Only for non-batch files like results.txt)
-		try:
-			with open(summary_path, 'r', encoding='utf-8') as f:
-				content = f.read()
-				files_match = re.search(r'Files processed:\s+(\d+)', content)
-				warnings_match = re.search(r'Total warnings:\s+(\d+)', content)
-				errors_match = re.search(r'Total errors:\s+(\d+)', content)
-				issues_match = re.search(r'Files with issues:\s+(\d+)', content)
-				clean_match = re.search(r'Clean files:\s+(\d+)', content)
-
-				if files_match:
-					return {
-						'files': int(files_match.group(1)),
-						'warnings': int(warnings_match.group(1)) if warnings_match else 0,
-						'errors': int(errors_match.group(1)) if errors_match else 0,
-						'issues': int(issues_match.group(1)) if issues_match else 0,
-						'clean': int(clean_match.group(1)) if clean_match else 0,
-					}
-		except (OSError, IOError):
-			pass  # If we can't read it, fall through to aggregation logic
-
-	# If not a batch file, no aggregation needed
 	if not is_batch_file:
 		return None
 
@@ -1481,15 +1465,11 @@ def main():
 		)
 		print("\n" + f"📝 Results written to: {results_path}")
 
-		# Aggregate batch results if multiple batches exist
-		aggregated_totals = aggregate_batch_results(results_path)
-
-		# Use aggregated totals for final summary if available
-		if aggregated_totals:
-			total_warnings = aggregated_totals['warnings']
-			total_errors = aggregated_totals['errors']
-			processed_files = aggregated_totals['files']
-			files_with_issues = aggregated_totals['issues']
+		# Write _AGGREGATED_SUMMARY.txt across batch files (CI/disk artifact only).
+		# Each invocation prints its own honest totals; we no longer override the
+		# terminal summary with aggregated values, since pre-commit runs N separate
+		# processes and the escalating per-batch overrides were confusing.
+		aggregate_batch_results(results_path)
 
 	# Print final summary
 	print_final_summary(

--- a/tests/unit/test_batch_cleanup.py
+++ b/tests/unit/test_batch_cleanup.py
@@ -1,0 +1,171 @@
+"""
+Unit tests for batch result cleanup and aggregation.
+
+Covers the regression where a stale ``results_AGGREGATED_SUMMARY.txt`` from a
+previous run polluted a later (passing) run's reported totals.
+"""
+
+import os
+import sys
+import shutil
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+current_dir = Path(__file__).parent
+tests_dir = current_dir.parent
+project_root = tests_dir.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from ignition_lint.cli import aggregate_batch_results, cleanup_old_batch_files
+
+
+def _set_old_mtime(path: Path, age_seconds: int = 60) -> None:
+	"""Backdate a file's mtime so cleanup treats it as stale."""
+	old_time = time.time() - age_seconds
+	os.utime(path, (old_time, old_time))
+
+
+class TestCleanupOldBatchFiles(unittest.TestCase):
+	"""Tests for cleanup_old_batch_files()."""
+
+	def setUp(self):
+		self.temp_dir = tempfile.mkdtemp()
+		self.temp_path = Path(self.temp_dir)
+		self.results_path = self.temp_path / "results.txt"
+
+	def tearDown(self):
+		shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+	def test_stale_aggregated_summary_is_deleted(self):
+		"""Stale _AGGREGATED_SUMMARY.txt from a previous run is removed."""
+		summary = self.temp_path / "results_AGGREGATED_SUMMARY.txt"
+		summary.write_text("Total errors:         99\n")
+		_set_old_mtime(summary)
+
+		cleanup_old_batch_files(self.results_path)
+
+		self.assertFalse(
+			summary.exists(),
+			"Stale aggregated summary should have been deleted",
+		)
+
+	def test_fresh_aggregated_summary_is_preserved(self):
+		"""Recent summary (< 5s) is kept to protect parallel processes."""
+		summary = self.temp_path / "results_AGGREGATED_SUMMARY.txt"
+		summary.write_text("Total errors:         5\n")
+		# Leave mtime at "now" — fresh file.
+
+		cleanup_old_batch_files(self.results_path)
+
+		self.assertTrue(
+			summary.exists(),
+			"Fresh aggregated summary must not be deleted (parallel-process safety)",
+		)
+
+	def test_stale_base_results_file_is_deleted(self):
+		"""Stale results.txt from previous run is removed."""
+		self.results_path.write_text("Total errors: 99\n")
+		_set_old_mtime(self.results_path)
+
+		cleanup_old_batch_files(self.results_path)
+
+		self.assertFalse(self.results_path.exists())
+
+	def test_stale_batch_files_from_other_pid_are_deleted(self):
+		"""Old batch files from a different PID are cleaned up."""
+		other_pid = os.getpid() + 1  # any PID that isn't ours
+		stale_batch = self.temp_path / f"results_pid{other_pid}_batch1.txt"
+		stale_batch.write_text("Total errors: 1\n")
+		_set_old_mtime(stale_batch)
+
+		cleanup_old_batch_files(self.results_path)
+
+		self.assertFalse(stale_batch.exists())
+
+	def test_current_pid_batch_files_are_preserved(self):
+		"""Batch files from the current PID are never deleted."""
+		current_pid = os.getpid()
+		own_batch = self.temp_path / f"results_pid{current_pid}_batch1.txt"
+		own_batch.write_text("Total errors: 1\n")
+		_set_old_mtime(own_batch)  # even if mtime is old, same-PID is kept
+
+		cleanup_old_batch_files(self.results_path)
+
+		self.assertTrue(own_batch.exists())
+
+	def test_missing_directory_is_noop(self):
+		"""Cleanup on a non-existent parent directory does not raise."""
+		missing = self.temp_path / "does_not_exist" / "results.txt"
+		# Should simply return without raising.
+		cleanup_old_batch_files(missing)
+
+
+class TestAggregateBatchResults(unittest.TestCase):
+	"""Tests for aggregate_batch_results()."""
+
+	def setUp(self):
+		self.temp_dir = tempfile.mkdtemp()
+		self.temp_path = Path(self.temp_dir)
+
+	def tearDown(self):
+		shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+	def test_non_batch_path_does_not_read_stale_summary(self):
+		"""
+		Regression: a stale summary must not feed totals back to a single-file
+		run. Previously, calling with results.txt would read an existing
+		AGGREGATED_SUMMARY and return its (stale) numbers.
+		"""
+		stale_summary = self.temp_path / "results_AGGREGATED_SUMMARY.txt"
+		stale_summary.write_text(
+			"Files processed:      10\n"
+			"Total warnings:       50\n"
+			"Total errors:         99\n"
+			"Files with issues:    8\n"
+			"Clean files:          2\n"
+		)
+
+		results_path = self.temp_path / "results.txt"
+		results_path.write_text("placeholder\n")
+
+		self.assertIsNone(
+			aggregate_batch_results(results_path),
+			"Non-batch path must return None even when a stale summary exists",
+		)
+
+	def test_batch_path_aggregates_existing_files(self):
+		"""When given a batch path with sibling result files, totals are summed."""
+		base = self.temp_path / "results.txt"
+		base.write_text(
+			"Files processed:      3\n"
+			"Total warnings:       4\n"
+			"Total errors:         1\n"
+			"Files with issues:    2\n"
+			"Clean files:          1\n"
+		)
+		batch1 = self.temp_path / f"results_pid{os.getpid()}_batch1.txt"
+		batch1.write_text(
+			"Files processed:      2\n"
+			"Total warnings:       1\n"
+			"Total errors:         3\n"
+			"Files with issues:    1\n"
+			"Clean files:          1\n"
+		)
+
+		totals = aggregate_batch_results(batch1)
+
+		self.assertIsNotNone(totals, "Batch path with multiple files should aggregate")
+		self.assertEqual(totals['files'], 5)
+		self.assertEqual(totals['warnings'], 5)
+		self.assertEqual(totals['errors'], 4)
+		self.assertEqual(totals['issues'], 3)
+		self.assertEqual(totals['clean'], 2)
+
+		summary = self.temp_path / "results_AGGREGATED_SUMMARY.txt"
+		self.assertTrue(summary.exists(), "Aggregated summary file should be written")
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary

Resolves a bug where `results_AGGREGATED_SUMMARY.txt` from a previous run leaked totals into a later (passing) run, so a clean current run could still report errors that no longer existed. Two paths caused this:

1. `cleanup_old_batch_files` explicitly skipped `AGGREGATED_SUMMARY` files, so they accumulated across runs.
2. `aggregate_batch_results` read an existing summary on non-batch paths and returned its (stale) totals, which the CLI used to override the printed "Summary" block.

This PR also scraps the terminal-summary override that was the consumer of (2). It was added to display aggregated totals across pre-commit batches, but pre-commit runs ignition-lint as N separate processes — producing escalating, conflicting summaries on screen as each batch finished. Each invocation now reports its own honest totals. The `_AGGREGATED_SUMMARY.txt` file is still written when batch files exist (kept as a CI/disk artifact).

Adds `tests/unit/test_batch_cleanup.py` covering the cleanup contract (stale deleted, fresh preserved, same-PID preserved, missing dir noop) and the aggregation contract (non-batch returns None even with stale summary present; batch path aggregates correctly). The repo previously had no tests for either function.

---

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] Feature (adds new functionality)
- [x] Chore (cleanup, refactoring, or maintenance)
- [ ] Documentation update

**Impact:**

- [ ] Breaking change (would cause existing functionality not to work as expected)
- [x] Non-breaking change
- [ ] Requires documentation update

---

## Change Log

**Client-Facing**

- **Fixed:** Stale `_AGGREGATED_SUMMARY.txt` from a previous run no longer pollutes a later passing run's reported totals.
- **Changed:** Each pre-commit batch invocation now reports its own honest totals to the terminal; the per-batch escalating summary override is removed. The `_AGGREGATED_SUMMARY.txt` file is still written when batch files exist.
- **Removed:** Dead code path in `aggregate_batch_results` that read existing summary files on non-batch paths.

**Internal**

- **Added:** `tests/unit/test_batch_cleanup.py` (8 tests) covering `cleanup_old_batch_files` and `aggregate_batch_results`.
- **Changed:** `cleanup_old_batch_files` now treats `_AGGREGATED_SUMMARY.txt` like other stale outputs (deleted when ≥5s old, preserved when fresh for parallel-process safety).

---

## Target Version

v0.4.2

---

## Related Issues

N/A

### Screenshots

N/A

## Review and Testing Notes

**Quick manual repro** to verify the original bug is gone:

```bash
mkdir -p .ignition-lint
cat > .ignition-lint/results_AGGREGATED_SUMMARY.txt <<'INNER'
================================================================================
AGGREGATED IGNITION-LINT RESULTS SUMMARY
================================================================================
Generated: 2025-01-01 00:00:00
Total batches: 2

TOTAL SUMMARY ACROSS ALL BATCHES
--------------------------------------------------------------------------------
Files processed:      10
Total warnings:       50
Total errors:         99
Files with issues:    8
Clean files:          2
INNER
touch -t 202501010000 .ignition-lint/results_AGGREGATED_SUMMARY.txt

poetry run ignition-lint \
  --config rule_config.json \
  --files "tests/cases/PascalCase/view.json" \
  --results-output .ignition-lint/results.txt
```

Before this PR: printed summary shows 99 errors. After: printed summary reflects the current run's actual totals, and the stale summary file is gone afterwards.

**Automated tests:**

```bash
cd tests && python -m unittest unit.test_batch_cleanup -v
```

All 8 new tests should pass. Full suite (`python test_runner.py --run-all`) also passes.

**Reviewer attention:**

- Confirm the fresh-summary preservation logic (`age < 5s`) is sufficient for your parallel pre-commit setups. Same threshold as the existing batch-file cleanup.
- The `_AGGREGATED_SUMMARY.txt` file is still being generated across batch files — sanity-check whether you actually want to keep it or scrap it entirely (we discussed scrapping the terminal override only).