### PR TITLE
fix: skip already-registered rules in discover_and_register_rules

### DIFF
--- a/src/ignition_lint/rules/registry.py
+++ b/src/ignition_lint/rules/registry.py
@@ -114,6 +114,10 @@ class RuleRegistry:
 						obj.__module__ == module_name
 					):
 
+						if self.is_registered(name):
+							discovered_rules.append(name)
+							continue
+
 						try:
 							rule_name = self.register_rule(obj)
 							discovered_rules.append(rule_name)


### PR DESCRIPTION
## Summary

- Rules using `@register_rule` are registered at import time (decoration pass). `discover_and_register_rules()` then finds them again via `inspect.getmembers()` and tries to re-register, triggering the "already registered" validation error and printing spurious warnings on every invocation.
- Fix: add an `is_registered()` guard before each registration attempt in `discover_and_register_rules()`. Already-decorated rules are appended to `discovered_rules` and skipped cleanly - no warning, no double work.
- Verified: all 10 rules register correctly with zero warnings after the fix.

## Test plan

- [ ] Run `ign-lint` against any project - confirm no "Skipped invalid rule" warnings appear
- [ ] Confirm all five previously-affected rules still lint correctly: `ExcessiveContextDataRule`, `UnusedCustomPropertiesRule`, `ExampleMixedSeverityRule`, `ExampleNameLengthRule`, `ComponentReferenceValidationRule`
- [ ] Confirm the four explicitly-imported rules still work: `NamePatternRule`, `PylintScriptRule`, `PollingIntervalRule`, `BadComponentReferenceRule`

Fixes #78