### PR TITLE
fix: credit parent object custom props when nested children are used (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `UnusedCustomPropertiesRule` no longer reports a false positive on a parent object/container custom property (e.g. `custom.network`) when only its nested children (`custom.network.nat1`/`nat2`) are bound or referenced. A property is now credited as used when any descendant path is bound or referenced. Reference detection is also made location-independent — references in scripts that are not modeled as their own nodes (e.g. property-change `onChange` scripts) are now detected the same as in transforms/event handlers — while preserving the component-vs-view namespace distinction (a bare `self.custom.X` does not credit a view-level property; only a nested `self.custom.X.child` does). [063379e]
+
 ## [0.5.2] - 2026-06-02
 
 ### Fixed

--- a/src/ignition_lint/rules/properties/unused_custom_properties.py
+++ b/src/ignition_lint/rules/properties/unused_custom_properties.py
@@ -194,18 +194,21 @@ class UnusedCustomPropertiesRule(LintingRule):
 				property_path = property_path.split(suffix)[0]
 				break
 
-		# Mark the property as used based on its type
-		if property_path.startswith('custom.') and '.' not in property_path[7:]:
-			# View-level custom property: custom.propName
-			prop_name = property_path[7:]
+		# Mark the property as used based on its type. We keep the full (possibly nested)
+		# property path so that a parent/container property can be credited when only its
+		# nested children are bound (e.g. custom.network.nat1 credits custom.network). See
+		# the descendant check in finalize().
+		if property_path.startswith('custom.'):
+			# View-level custom property: custom.propName (or custom.parent.child)
+			prop_name = property_path[len('custom.'):]
 			self.used_properties.add(f"view.custom.{prop_name}")
-		elif property_path.startswith('params.') and '.' not in property_path[7:]:
-			# View-level param: params.paramName
-			param_name = property_path[7:]
+		elif property_path.startswith('params.'):
+			# View-level param: params.paramName (or params.parent.child)
+			param_name = property_path[len('params.'):]
 			self.used_properties.add(f"view.params.{param_name}")
 		elif '.custom.' in property_path:
-			# Component custom property: something.custom.propName
-			custom_match = re.search(r'([^.]+)\.custom\.([^.]+)$', property_path)
+			# Component custom property: something.custom.propName (or .custom.parent.child)
+			custom_match = re.search(r'([^.]+)\.custom\.(.+)$', property_path)
 			if custom_match:
 				component_name = custom_match.group(1)
 				prop_name = custom_match.group(2)
@@ -239,11 +242,14 @@ class UnusedCustomPropertiesRule(LintingRule):
 			return
 
 		# Look for patterns like self.view.custom.propName, self.view.params.paramName, etc.
+		# The capture group greedily includes nested children (e.g. network.nat1) so that
+		# accessing a child of an object property credits the parent. See _is_property_used.
+		nested = r'([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)'
 		patterns = [
-			r'self\.view\.custom\.([a-zA-Z_][a-zA-Z0-9_]*)',  # self.view.custom.propName
-			r'self\.view\.params\.([a-zA-Z_][a-zA-Z0-9_]*)',  # self.view.params.paramName
-			r'self\.custom\.([a-zA-Z_][a-zA-Z0-9_]*)',  # self.custom.propName (component)
-			r'self\.params\.([a-zA-Z_][a-zA-Z0-9_]*)',  # self.params.propName (component)
+			rf'self\.view\.custom\.{nested}',  # self.view.custom.propName
+			rf'self\.view\.params\.{nested}',  # self.view.params.paramName
+			rf'self\.custom\.{nested}',  # self.custom.propName (component)
+			rf'self\.params\.{nested}',  # self.params.propName (component)
 		]
 
 		for pattern in patterns:
@@ -273,22 +279,8 @@ class UnusedCustomPropertiesRule(LintingRule):
 		unused_properties = []
 
 		for prop_path, definition_location in self.defined_properties.items():
-			# Check if this property is used
-			is_used = prop_path in self.used_properties
-			if is_used:
+			if self._is_property_used(prop_path):
 				continue
-
-			# For component custom properties, also check wildcard usage
-			if '.custom.' in prop_path and not prop_path.startswith('view.'):
-				# Extract just the property name for wildcard matching
-				prop_name = prop_path.split('.custom.')[-1]
-				if f"*.custom.{prop_name}" in self.used_properties:
-					continue
-
-			if prop_path.startswith('view.params.'):
-				prop_name = prop_path.split('view.params.')[-1]
-				if f"*.params.{prop_name}" in self.used_properties:
-					continue
 
 			# If we reach here, the property is unused
 			unused_properties.append((prop_path, definition_location))
@@ -299,6 +291,54 @@ class UnusedCustomPropertiesRule(LintingRule):
 			self.add_violation(
 				f"{definition_location}: {prop_type} '{prop_path.split('.')[-1]}' is defined but never referenced"
 			)
+
+	def _is_property_used(self, prop_path: str) -> bool:
+		"""
+		Determine whether a defined property is used.
+
+		A property is considered used if it is referenced/bound directly, OR if any of its
+		descendant paths are referenced/bound. The latter handles object/container properties
+		(e.g. custom.network) whose nested children (custom.network.nat1) are the things that
+		actually have bindings and references - the parent cannot be unused if its children are.
+		"""
+		# Direct usage
+		if prop_path in self.used_properties:
+			return True
+
+		# Descendant usage credits the parent (e.g. view.custom.network.nat1 -> view.custom.network)
+		descendant_prefix = f"{prop_path}."
+		if any(used.startswith(descendant_prefix) for used in self.used_properties):
+			return True
+
+		# Component custom properties are also tracked via wildcard keys (*.custom.propName)
+		if '.custom.' in prop_path and not prop_path.startswith('view.'):
+			prop_name = prop_path.split('.custom.')[-1]
+			if f"*.custom.{prop_name}" in self.used_properties:
+				return True
+			wildcard_prefix = f"*.custom.{prop_name}."
+			if any(used.startswith(wildcard_prefix) for used in self.used_properties):
+				return True
+
+		# A view-level object custom property may have its children accessed via the
+		# component-relative self.custom.X.child form in scripts (recorded as *.custom.X.child).
+		# We only credit on a nested child access (not a bare *.custom.X) to preserve the
+		# strict view-level behavior for plain self.custom.X references.
+		if prop_path.startswith('view.custom.'):
+			prop_name = prop_path.split('view.custom.')[-1]
+			wildcard_prefix = f"*.custom.{prop_name}."
+			if any(used.startswith(wildcard_prefix) for used in self.used_properties):
+				return True
+
+		# View params may be referenced via component-relative self.params (*.params.paramName)
+		if prop_path.startswith('view.params.'):
+			prop_name = prop_path.split('view.params.')[-1]
+			if f"*.params.{prop_name}" in self.used_properties:
+				return True
+			wildcard_prefix = f"*.params.{prop_name}."
+			if any(used.startswith(wildcard_prefix) for used in self.used_properties):
+				return True
+
+		return False
 
 	def _search_flattened_json_for_references(self):
 		"""Search the entire flattened JSON for any references to defined properties."""
@@ -346,6 +386,14 @@ class UnusedCustomPropertiesRule(LintingRule):
 				if pattern in json_value:
 					# Mark the corresponding property as used
 					self._mark_property_used_from_pattern(pattern)
+
+			# Apply the full reference detectors to every string value so that detection is
+			# location-independent. This catches references (notably the component-relative
+			# self.custom.X / self.params.X form) inside scripts that are not modeled as their
+			# own nodes - e.g. property-change (onChange) scripts - which would otherwise only
+			# be matched by the narrower substring patterns above.
+			self._check_script_for_references(json_value)
+			self._check_expression_for_references(json_value)
 
 	def _mark_property_used_from_pattern(self, pattern: str):
 		"""Mark a property as used based on a found pattern."""

--- a/tests/unit/test_unused_custom_properties.py
+++ b/tests/unit/test_unused_custom_properties.py
@@ -9,10 +9,9 @@ SUPPORTED FEATURES:
 - ✅ Detects view parameters (params.*)
 - ✅ Detects component-level custom properties (*.custom.*)
 - ✅ Detects when properties are used in expression bindings
+- ✅ Detects when properties are referenced in scripts (location-independent string scan)
+- ✅ Credits parent/container object properties when their nested children are bound or referenced
 - ✅ Correctly handles persistent vs non-persistent properties
-
-REMAINING LIMITATIONS:
-- Does not detect when properties are used in scripts (scripts not processed by model builder)
 """
 
 import json
@@ -324,7 +323,8 @@ class TestUnusedCustomPropertiesRule(BaseRuleTest):  # pylint: disable=too-many-
 							},
 							"transforms": [{
 								"type": "script",
-								"code": "# Access root param via self.params\nreturn self.params.rootParam"
+								"code":
+									"# Access root param via self.params\nreturn self.params.rootParam"
 							}],
 							"type": "expr"
 						}
@@ -372,7 +372,8 @@ class TestUnusedCustomPropertiesRule(BaseRuleTest):  # pylint: disable=too-many-
 						"component": {
 							"onActionPerformed": {
 								"config": {
-									"script": "logger.info(self.params.usedInEventHandler)"
+									"script":
+										"logger.info(self.params.usedInEventHandler)"
 								},
 								"scope": "G",
 								"type": "script"
@@ -482,7 +483,8 @@ class TestUnusedCustomPropertiesRule(BaseRuleTest):  # pylint: disable=too-many-
 					"scripts": {
 						"customMethods": [{
 							"name": "myMethod",
-							"script": "return self.view.custom.methodValue + str(self.custom.myProp)"
+							"script":
+								"return self.view.custom.methodValue + str(self.custom.myProp)"
 						}]
 					}
 				}],
@@ -555,7 +557,8 @@ class TestUnusedCustomPropertiesRule(BaseRuleTest):  # pylint: disable=too-many-
 							"binding": {
 								"type": "expression",
 								"config": {
-									"expression": "{self.view.custom.selfViewProp} + {self.view.params.selfViewParam}"
+									"expression":
+										"{self.view.custom.selfViewProp} + {self.view.params.selfViewParam}"
 								}
 							}
 						}
@@ -855,3 +858,317 @@ class TestUnusedCustomPropertiesRule(BaseRuleTest):  # pylint: disable=too-many-
 			mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=3,
 			error_patterns=["unusedInput", "unusedCustom", "outputWithoutBinding"]
 		)
+
+	def test_object_custom_property_with_bound_children(self):
+		"""Parent object custom property is used when its children have bindings (issue #97)."""
+		# custom.network is an object whose nested children (nat1, nat2) have tag bindings
+		# and are referenced in an onChange script. The parent must be considered used.
+		view_data = {
+			"custom": {
+				"network": {}
+			},
+			"propConfig": {
+				"custom.network": {
+					"onChange": {
+						"enabled": None,
+						"script":
+							"\tif self.custom.network.nat1 == \"0.0.0.0\" and "
+							"self.custom.network.nat2 == \"0.0.0.0\":\n\t\tpass"
+					},
+					"persistent": True
+				},
+				"custom.network.nat1": {
+					"binding": {
+						"config": {
+							"mode": "indirect",
+							"tagPath": "[default]Path/IPAddressNat1"
+						},
+						"type": "tag"
+					}
+				},
+				"custom.network.nat2": {
+					"binding": {
+						"config": {
+							"mode": "indirect",
+							"tagPath": "[default]Path/IPAddressNat2"
+						},
+						"type": "tag"
+					}
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# Parent custom.network should NOT be flagged - its children are bound and referenced
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_object_custom_property_with_referenced_child_only(self):
+		"""Parent object custom property is used when a nested child is referenced in a script."""
+		view_data = {
+			"custom": {
+				"settings": {
+					"timeout": 5000
+				}
+			},
+			"root": {
+				"children": [{
+					"meta": {
+						"name": "TestButton"
+					},
+					"type": "ia.input.button",
+					"events": {
+						"onClick": {
+							"script": "logger.info(self.view.custom.settings.timeout)"
+						}
+					}
+				}],
+				"meta": {
+					"name": "root"
+				}
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# Parent custom.settings should NOT be flagged - its child .timeout is referenced
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_object_component_custom_property_with_referenced_child(self):
+		"""Parent object component custom property is used when a nested child is referenced."""
+		view_data = {
+			"root": {
+				"children": [{
+					"meta": {
+						"name": "TestLabel"
+					},
+					"type": "ia.display.label",
+					"custom": {
+						"config": {
+							"color": "red"
+						}
+					},
+					"props": {
+						"text": {
+							"binding": {
+								"type": "expression",
+								"config": {
+									"expression": "{this.custom.config.color}"
+								}
+							}
+						}
+					}
+				}],
+				"meta": {
+					"name": "root"
+				}
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# Parent component custom.config should NOT be flagged - its child .color is referenced
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_unused_object_custom_property_still_flagged(self):
+		"""An object custom property with no referenced/bound children is still flagged as unused."""
+		# Parent object is defined (via propConfig) and has a child (nat1) that is neither
+		# bound nor referenced anywhere, so the parent must still be reported as unused.
+		view_data = {
+			"custom": {
+				"unusedNetwork": {}
+			},
+			"propConfig": {
+				"custom.unusedNetwork": {
+					"persistent": True
+				},
+				"custom.unusedNetwork.nat1": {
+					"persistent": True
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# No children are referenced or bound, so the object property is unused
+		self.assert_rule_errors(
+			mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=1,
+			error_patterns=["unusedNetwork", "never referenced"]
+		)
+
+	def test_object_child_binding_does_not_credit_sibling_prefix(self):
+		"""Crediting a parent for child usage must not leak to a name-prefix sibling."""
+		# custom.net and custom.network share a name prefix. Only network has a bound child,
+		# so custom.net must still be flagged (the trailing-dot guard prevents false crediting).
+		view_data = {
+			"custom": {
+				"net": "x",
+				"network": {}
+			},
+			"propConfig": {
+				"custom.network": {
+					"persistent": True
+				},
+				"custom.network.nat1": {
+					"binding": {
+						"config": {
+							"tagPath": "[default]Path/Nat1"
+						},
+						"type": "tag"
+					}
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				}
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# Only custom.net should be flagged; custom.network is credited by its bound child.
+		self.assert_rule_errors(
+			mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=1,
+			error_patterns=["net", "never referenced"]
+		)
+
+	def test_view_object_custom_nested_child_in_event_script(self):
+		"""A view object custom prop is used when a nested child is read via self.custom in a script."""
+		view_data = {
+			"custom": {
+				"network": {}
+			},
+			"propConfig": {
+				"custom.network": {
+					"persistent": True
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"children": [{
+					"meta": {
+						"name": "Btn"
+					},
+					"type": "ia.input.button",
+					"events": {
+						"component": {
+							"onActionPerformed": {
+								"config": {
+									"script": "x = self.custom.network.nat1"
+								},
+								"type": "script"
+							}
+						}
+					}
+				}]
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# The nested child access credits the parent object property.
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_plain_self_custom_does_not_credit_view_level_scalar(self):
+		"""A bare self.custom.X (no nested child) must not credit a view-level property."""
+		# self.custom is component-relative; without a nested child access it should not
+		# silently mark an unrelated view-level custom property as used.
+		view_data = {
+			"custom": {
+				"network": "scalar"
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"children": [{
+					"meta": {
+						"name": "Btn"
+					},
+					"type": "ia.input.button",
+					"events": {
+						"component": {
+							"onActionPerformed": {
+								"config": {
+									"script": "x = self.custom.network"
+								},
+								"type": "script"
+							}
+						}
+					}
+				}]
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# view.custom.network is a scalar referenced only via component-relative self.custom,
+		# so it remains unused (strict view-level behavior is preserved).
+		self.assert_rule_errors(
+			mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=1,
+			error_patterns=["network", "never referenced"]
+		)
+
+	def test_object_child_referenced_in_unmodeled_onchange_script(self):
+		"""Reference detection is location-independent: a nested child read in an onChange script counts.
+
+		Property-change (onChange) scripts are not modeled as their own script nodes, but their
+		text is still scanned, so a self.custom.X.child reference there must credit the parent
+		object property the same way it would in a transform or event handler.
+		"""
+		view_data = {
+			"custom": {
+				"network": {}
+			},
+			"propConfig": {
+				"custom.network": {
+					"onChange": {
+						"enabled": None,
+						"script": "\tif self.custom.network.nat1 == \"0.0.0.0\":\n\t\tpass"
+					},
+					"persistent": True
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# The nested child access in the onChange script credits the parent object property.
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)


### PR DESCRIPTION
## Summary

`UnusedCustomPropertiesRule` falsely reported a **parent** object/container custom property (e.g. `custom.network`) as "defined but never referenced" when only its **nested children** (`custom.network.nat1`/`nat2`) were the things actually bound and referenced. Since a child cannot exist without its parent, the parent is necessarily in use.

This PR fixes the false positive by crediting a property as used whenever any of its descendant paths are bound or referenced, and makes reference detection location-independent so the same reference text is detected regardless of where it appears.

---

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] Feature (adds new functionality)
- [ ] Chore (cleanup, refactoring, or maintenance)
- [ ] Documentation update

**Impact:**

- [ ] Breaking change (would cause existing functionality not to work as expected)
- [x] Non-breaking change
- [ ] Requires documentation update

---

## Change Log

### Internal

**Fixed**
- `_mark_binding_owner_as_used` now records full nested binding-owner paths instead of dropping them, so a bound child credits its parent.
- New `_is_property_used` helper: a property is used if it (or any descendant path) is bound/referenced. The trailing-dot prefix check prevents name-prefix sibling collisions (`custom.net` vs `custom.network`).
- Script reference regexes now capture nested child paths.
- Reference detection is **location-independent**: the regex detectors run over every flattened string value, so references in scripts that are not modeled as their own nodes (e.g. property-change `onChange` scripts) are detected the same as in transforms/event handlers.

**Changed**
- Preserved the component-vs-view namespace distinction: a bare `self.custom.X` does not credit a view-level property; only a nested `self.custom.X.child` does.

**Added**
- Regression tests covering bound/referenced children for view, component, and param object properties; sibling-prefix isolation; modeled and unmodeled script references; and the strictness guard.

---

## Target Version

0.5.3

---

## Related Issues

Closes #97

### Screenshots

N/A

## Review and Testing Notes

- Full test suite passes (`cd tests && python test_runner.py --run-all`): unit + integration + config.
- Source file is pylint 10.00/10 and yapf-clean; the test file is yapf-clean.
- Reproduce the original bug with the minimal view in #97 and `UnusedCustomPropertiesRule` enabled — it now reports no errors.
- **Known, out-of-scope note:** property-change (`onChange`) scripts are still not built as first-class script nodes in the object model. This no longer affects this rule, but other script-oriented rules (e.g. `PylintScriptRule`) won't lint `onChange` script bodies. Separate issue was created: #99 