### PR TITLE
feat: model property-change (onChange) scripts as first-class script nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Property-change (`onChange`) scripts defined under `propConfig.<property>.onChange.script` (view-level and component-level) are now modeled as first-class `PropertyChangeScript` nodes. Previously they were not built into any script node, so script-oriented rules such as `PylintScriptRule` silently skipped their bodies; those scripts are now linted and counted in model statistics. New `NodeType.PROPERTY_CHANGE_SCRIPT` and `property_change_scripts` model collection. (#99)
+
 ## [0.5.2] - 2026-06-02
 
 ### Fixed

--- a/src/ignition_lint/linter.py
+++ b/src/ignition_lint/linter.py
@@ -71,7 +71,7 @@ class LintEngine:
 		specific_collections = [
 			'components', 'message_handlers', 'custom_methods', 'expression_bindings',
 			'expression_struct_bindings', 'property_bindings', 'tag_bindings', 'query_bindings',
-			'script_transforms', 'event_handlers', 'properties'
+			'script_transforms', 'event_handlers', 'property_change_scripts', 'properties'
 		]
 		all_nodes = []
 		for collection_name in specific_collections:
@@ -225,7 +225,7 @@ class LintEngine:
 		specific_collections = [
 			'components', 'message_handlers', 'custom_methods', 'expression_bindings',
 			'expression_struct_bindings', 'property_bindings', 'tag_bindings', 'query_bindings',
-			'script_transforms', 'event_handlers', 'properties'
+			'script_transforms', 'event_handlers', 'property_change_scripts', 'properties'
 		]
 		all_nodes = []
 		for collection_name in specific_collections:

--- a/src/ignition_lint/model/builder.py
+++ b/src/ignition_lint/model/builder.py
@@ -18,6 +18,7 @@ from .node_types import (
 	CustomMethodScript,
 	TransformScript,
 	EventHandlerScript,
+	PropertyChangeScript,
 	Property,
 )
 
@@ -40,6 +41,7 @@ class ViewModelBuilder:
 			'tag_bindings': [],
 			'query_bindings': [],
 			'script_transforms': [],
+			'property_change_scripts': [],
 			'properties': []
 		}
 		self._propconfig_cache = None  # Cache for propConfig paths (performance optimization)
@@ -507,6 +509,36 @@ class ViewModelBuilder:
 					self.model['event_handlers'].append(handler)
 					self.model['scripts'].append(handler)
 
+	def _collect_property_change_scripts(self):
+		"""Collect property-change (onChange) scripts defined under propConfig.
+
+		These live at ``[<component>.]propConfig.<property>.onChange.script`` for both
+		view-level (e.g. ``propConfig.custom.total.onChange.script``) and component-level
+		properties. They are not under ``.events.`` so the event-handler collector misses
+		them; without this they become no script node of any kind and script-oriented
+		rules (e.g. PylintScriptRule) never see their bodies.
+		"""
+		suffix = '.onChange.script'
+		for path, script in self.flattened_json.items():
+			if not path.endswith(suffix):
+				continue
+			# Only propConfig-scoped onChange handlers are property-change scripts.
+			if not (path.startswith('propConfig.') or '.propConfig.' in path):
+				continue
+
+			# Node path is the onChange object path (drop the trailing '.script').
+			node_path = path[:-len('.script')]
+
+			# Property path is everything between the 'propConfig.' marker and '.onChange'.
+			prop_segment = path[:-len(suffix)]
+			marker = 'propConfig.'
+			marker_index = prop_segment.rfind(marker)
+			property_path = prop_segment[marker_index + len(marker):]
+
+			handler = PropertyChangeScript(node_path, script, property_path)
+			self.model['property_change_scripts'].append(handler)
+			self.model['scripts'].append(handler)
+
 	def _collect_properties(self):
 		# Track processed properties to avoid duplicates from array elements
 		# Key format: "base_path.property_name" (without array indices)
@@ -642,6 +674,7 @@ class ViewModelBuilder:
 			'tag_bindings': [],
 			'query_bindings': [],
 			'script_transforms': [],
+			'property_change_scripts': [],
 			'properties': []
 		}
 
@@ -659,6 +692,9 @@ class ViewModelBuilder:
 
 		# Process event handlers
 		self._collect_event_handlers()
+
+		# Process property-change (onChange) scripts
+		self._collect_property_change_scripts()
 
 		# Process regular properties
 		self._collect_properties()

--- a/src/ignition_lint/model/node_types.py
+++ b/src/ignition_lint/model/node_types.py
@@ -22,6 +22,7 @@ class NodeType(Enum):
 	CUSTOM_METHOD = "custom_method"
 	TRANSFORM = "transform"
 	EVENT_HANDLER = "event_handler"
+	PROPERTY_CHANGE_SCRIPT = "property_change_script"
 	PROPERTY = "property"
 
 
@@ -30,7 +31,10 @@ ALL_BINDINGS = {
 	NodeType.EXPRESSION_BINDING, NodeType.EXPRESSION_STRUCT_BINDING, NodeType.PROPERTY_BINDING,
 	NodeType.TAG_BINDING, NodeType.QUERY_BINDING
 }
-ALL_SCRIPTS = {NodeType.MESSAGE_HANDLER, NodeType.CUSTOM_METHOD, NodeType.TRANSFORM, NodeType.EVENT_HANDLER}
+ALL_SCRIPTS = {
+	NodeType.MESSAGE_HANDLER, NodeType.CUSTOM_METHOD, NodeType.TRANSFORM, NodeType.EVENT_HANDLER,
+	NodeType.PROPERTY_CHANGE_SCRIPT
+}
 
 
 class ViewNode(ABC):
@@ -297,6 +301,25 @@ class EventHandlerScript(ScriptNode):
 			'event_type': self.event_type,
 			'scope': self.scope
 		})
+		return base_attrs
+
+
+class PropertyChangeScript(ScriptNode):
+	"""Represents a property-change (onChange) script defined under propConfig.
+
+	These scripts run when a custom/params property's value changes. In Ignition
+	Perspective they receive the previous and current values along with change
+	metadata, so the generated function signature mirrors that contract.
+	"""
+
+	def __init__(self, path: str, script: str, property_path: str):
+		super().__init__(path, NodeType.PROPERTY_CHANGE_SCRIPT, script)
+		self.property_path = property_path
+		self.function_def = "def valueChanged(self, previousValue, currentValue, origin, missedEvents):"
+
+	def _get_serializable_attrs(self) -> Dict[str, Any]:
+		base_attrs = super()._get_serializable_attrs()
+		base_attrs.update({'property_path': self.property_path})
 		return base_attrs
 
 

--- a/src/ignition_lint/rules/common.py
+++ b/src/ignition_lint/rules/common.py
@@ -307,6 +307,9 @@ class ScriptRule(LintingRule):
 	def visit_event_handler(self, node: ViewNode):
 		self._collect_script(node)
 
+	def visit_property_change_script(self, node: ViewNode):
+		self._collect_script(node)
+
 	def _collect_script(self, node: ViewNode):
 		"""Collect script for batch processing."""
 		if isinstance(node, ScriptNode):

--- a/src/ignition_lint/rules/scripts/lint_script.py
+++ b/src/ignition_lint/rules/scripts/lint_script.py
@@ -202,7 +202,9 @@ class PylintScriptRule(FixableMixin, ScriptRule):
 			suffix_candidates = ['.code']
 		elif node.node_type == NodeType.EVENT_HANDLER:
 			suffix_candidates = ['.config.script', '.script']
-		elif node.node_type in (NodeType.MESSAGE_HANDLER, NodeType.CUSTOM_METHOD):
+		elif node.node_type in (
+			NodeType.MESSAGE_HANDLER, NodeType.CUSTOM_METHOD, NodeType.PROPERTY_CHANGE_SCRIPT
+		):
 			suffix_candidates = ['.script']
 
 		for suffix in suffix_candidates:

--- a/tests/debug/cases/AllNodeTypes/model.json
+++ b/tests/debug/cases/AllNodeTypes/model.json
@@ -378,6 +378,10 @@
       }
     ]
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 1,
     "nodes": [

--- a/tests/debug/cases/AllNodeTypes/stats.json
+++ b/tests/debug/cases/AllNodeTypes/stats.json
@@ -15,6 +15,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -35,6 +36,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -78,6 +80,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/AllScriptTypes/model.json
+++ b/tests/debug/cases/AllScriptTypes/model.json
@@ -193,6 +193,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/AllScriptTypes/stats.json
+++ b/tests/debug/cases/AllScriptTypes/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -35,6 +36,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -78,6 +80,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/BadComponentReferences/model.json
+++ b/tests/debug/cases/BadComponentReferences/model.json
@@ -949,6 +949,10 @@
       }
     ]
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/BadComponentReferences/stats.json
+++ b/tests/debug/cases/BadComponentReferences/stats.json
@@ -17,6 +17,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -36,6 +37,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -79,6 +81,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/BadContextData/model.json
+++ b/tests/debug/cases/BadContextData/model.json
@@ -1360,6 +1360,10 @@
       }
     ]
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/BadContextData/stats.json
+++ b/tests/debug/cases/BadContextData/stats.json
@@ -19,6 +19,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -38,6 +39,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -81,6 +83,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/ExpressionBindings/model.json
+++ b/tests/debug/cases/ExpressionBindings/model.json
@@ -342,19 +342,19 @@
         "value_type": "NoneType"
       },
       {
-        "name": "expressionStructurePolling",
-        "node_type": "property",
-        "path": "custom.expressionStructurePolling",
-        "persistent": false,
-        "value": null,
-        "value_type": "NoneType"
-      },
-      {
         "name": "expressionPolling",
         "node_type": "property",
         "path": "custom.expressionPolling",
         "persistent": false,
         "private_access": true,
+        "value": null,
+        "value_type": "NoneType"
+      },
+      {
+        "name": "expressionStructurePolling",
+        "node_type": "property",
+        "path": "custom.expressionStructurePolling",
+        "persistent": false,
         "value": null,
         "value_type": "NoneType"
       }
@@ -377,6 +377,18 @@
       }
     ]
   },
+  "property_change_scripts": {
+    "count": 1,
+    "nodes": [
+      {
+        "node_type": "property_change_script",
+        "path": "propConfig.custom.test.onChange",
+        "property_path": "custom.test",
+        "script_length": 48,
+        "script_preview": "\treturn previousValue.value * currentValue.value"
+      }
+    ]
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []
@@ -386,7 +398,7 @@
     "nodes": []
   },
   "scripts": {
-    "count": 2,
+    "count": 3,
     "nodes": [
       {
         "name": "custom_binding_refresh",
@@ -407,6 +419,13 @@
         "scope": "G",
         "script_length": 13,
         "script_preview": "\treturn event"
+      },
+      {
+        "node_type": "property_change_script",
+        "path": "propConfig.custom.test.onChange",
+        "property_path": "custom.test",
+        "script_length": 48,
+        "script_preview": "\treturn previousValue.value * currentValue.value"
       }
     ]
   },

--- a/tests/debug/cases/ExpressionBindings/stats.json
+++ b/tests/debug/cases/ExpressionBindings/stats.json
@@ -18,6 +18,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -27,16 +28,18 @@
     "expression_binding": 8,
     "expression_struct_binding": 1,
     "property": 19,
-    "property_binding": 2
+    "property_binding": 2,
+    "property_change_script": 1
   },
   "rule_coverage": {
     "BadComponentReferenceRule": {
-      "applicable_node_count": 10,
+      "applicable_node_count": 11,
       "target_types": [
         "custom_method",
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -53,7 +56,7 @@
       ]
     },
     "ExcessiveContextDataRule": {
-      "applicable_node_count": 36,
+      "applicable_node_count": 37,
       "target_types": [
         "all"
       ]
@@ -75,11 +78,12 @@
       ]
     },
     "PylintScriptRule": {
-      "applicable_node_count": 2,
+      "applicable_node_count": 3,
       "target_types": [
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -98,5 +102,5 @@
       ]
     }
   },
-  "total_nodes": 36
+  "total_nodes": 37
 }

--- a/tests/debug/cases/LineDashboard/model.json
+++ b/tests/debug/cases/LineDashboard/model.json
@@ -1518,18 +1518,18 @@
         "value_type": "str"
       },
       {
-        "name": "start_date",
+        "name": "mode_name",
         "node_type": "property",
-        "path": "custom.start_date",
+        "path": "custom.mode_name",
         "persistent": false,
         "private_access": true,
         "value": null,
         "value_type": "NoneType"
       },
       {
-        "name": "end_date",
+        "name": "start_date",
         "node_type": "property",
-        "path": "custom.end_date",
+        "path": "custom.start_date",
         "persistent": false,
         "private_access": true,
         "value": null,
@@ -1553,15 +1553,6 @@
         "value_type": "NoneType"
       },
       {
-        "name": "eq_path",
-        "node_type": "property",
-        "path": "custom.eq_path",
-        "persistent": false,
-        "private_access": true,
-        "value": null,
-        "value_type": "NoneType"
-      },
-      {
         "name": "update",
         "node_type": "property",
         "path": "custom.update",
@@ -1571,9 +1562,9 @@
         "value_type": "NoneType"
       },
       {
-        "name": "is_nav_expanded",
+        "name": "eq_path",
         "node_type": "property",
-        "path": "custom.is_nav_expanded",
+        "path": "custom.eq_path",
         "persistent": false,
         "private_access": true,
         "value": null,
@@ -1589,6 +1580,24 @@
         "value_type": "NoneType"
       },
       {
+        "name": "kpiTargets",
+        "node_type": "property",
+        "path": "custom.kpiTargets",
+        "persistent": false,
+        "private_access": true,
+        "value": null,
+        "value_type": "NoneType"
+      },
+      {
+        "name": "end_date",
+        "node_type": "property",
+        "path": "custom.end_date",
+        "persistent": false,
+        "private_access": true,
+        "value": null,
+        "value_type": "NoneType"
+      },
+      {
         "name": "state_type",
         "node_type": "property",
         "path": "custom.state_type",
@@ -1598,9 +1607,9 @@
         "value_type": "NoneType"
       },
       {
-        "name": "mode_name",
+        "name": "adjusted_time",
         "node_type": "property",
-        "path": "custom.mode_name",
+        "path": "custom.adjusted_time",
         "persistent": false,
         "private_access": true,
         "value": null,
@@ -1610,15 +1619,6 @@
         "name": "state_name",
         "node_type": "property",
         "path": "custom.state_name",
-        "persistent": false,
-        "private_access": true,
-        "value": null,
-        "value_type": "NoneType"
-      },
-      {
-        "name": "kpiTargets",
-        "node_type": "property",
-        "path": "custom.kpiTargets",
         "persistent": false,
         "private_access": true,
         "value": null,
@@ -1643,9 +1643,9 @@
         "value_type": "NoneType"
       },
       {
-        "name": "adjusted_time",
+        "name": "is_nav_expanded",
         "node_type": "property",
-        "path": "custom.adjusted_time",
+        "path": "custom.is_nav_expanded",
         "persistent": false,
         "private_access": true,
         "value": null,
@@ -1789,6 +1789,10 @@
         "target_path": "view.custom.time"
       }
     ]
+  },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
   },
   "query_bindings": {
     "count": 0,

--- a/tests/debug/cases/LineDashboard/stats.json
+++ b/tests/debug/cases/LineDashboard/stats.json
@@ -21,6 +21,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -43,6 +44,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -86,6 +88,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/MixedCase/model.json
+++ b/tests/debug/cases/MixedCase/model.json
@@ -422,6 +422,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/MixedCase/stats.json
+++ b/tests/debug/cases/MixedCase/stats.json
@@ -17,6 +17,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -31,6 +32,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -74,6 +76,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/PascalCase/model.json
+++ b/tests/debug/cases/PascalCase/model.json
@@ -102,6 +102,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/PascalCase/stats.json
+++ b/tests/debug/cases/PascalCase/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -30,6 +31,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -73,6 +75,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/PreferredStyle/model.json
+++ b/tests/debug/cases/PreferredStyle/model.json
@@ -102,6 +102,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/PreferredStyle/stats.json
+++ b/tests/debug/cases/PreferredStyle/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -30,6 +31,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -73,6 +75,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/PylintViolations/model.json
+++ b/tests/debug/cases/PylintViolations/model.json
@@ -111,6 +111,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/PylintViolations/stats.json
+++ b/tests/debug/cases/PylintViolations/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -35,6 +36,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -78,6 +80,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/Title Case/model.json
+++ b/tests/debug/cases/Title Case/model.json
@@ -80,6 +80,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/Title Case/stats.json
+++ b/tests/debug/cases/Title Case/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -30,6 +31,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -73,6 +75,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/UPPER_CASE/model.json
+++ b/tests/debug/cases/UPPER_CASE/model.json
@@ -102,6 +102,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/UPPER_CASE/stats.json
+++ b/tests/debug/cases/UPPER_CASE/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -30,6 +31,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -73,6 +75,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/camelCase/model.json
+++ b/tests/debug/cases/camelCase/model.json
@@ -97,17 +97,17 @@
         "value_type": "str"
       },
       {
-        "name": "snake_case_test_custom",
+        "name": "snake_case_test_param",
         "node_type": "property",
-        "path": "custom.snake_case_test_custom",
+        "path": "params.snake_case_test_param",
         "persistent": false,
         "value": null,
         "value_type": "NoneType"
       },
       {
-        "name": "snake_case_test_param",
+        "name": "snake_case_test_custom",
         "node_type": "property",
-        "path": "params.snake_case_test_param",
+        "path": "custom.snake_case_test_custom",
         "persistent": false,
         "value": null,
         "value_type": "NoneType"
@@ -115,6 +115,10 @@
     ]
   },
   "property_bindings": {
+    "count": 0,
+    "nodes": []
+  },
+  "property_change_scripts": {
     "count": 0,
     "nodes": []
   },

--- a/tests/debug/cases/camelCase/stats.json
+++ b/tests/debug/cases/camelCase/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -30,6 +31,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -73,6 +75,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/inconsistentCase/model.json
+++ b/tests/debug/cases/inconsistentCase/model.json
@@ -344,6 +344,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/inconsistentCase/stats.json
+++ b/tests/debug/cases/inconsistentCase/stats.json
@@ -17,6 +17,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -31,6 +32,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -74,6 +76,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/kebab-case/model.json
+++ b/tests/debug/cases/kebab-case/model.json
@@ -102,6 +102,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/kebab-case/stats.json
+++ b/tests/debug/cases/kebab-case/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -30,6 +31,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -73,6 +75,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/debug/cases/snake_case/model.json
+++ b/tests/debug/cases/snake_case/model.json
@@ -102,6 +102,10 @@
     "count": 0,
     "nodes": []
   },
+  "property_change_scripts": {
+    "count": 0,
+    "nodes": []
+  },
   "query_bindings": {
     "count": 0,
     "nodes": []

--- a/tests/debug/cases/snake_case/stats.json
+++ b/tests/debug/cases/snake_case/stats.json
@@ -16,6 +16,7 @@
     "tag_bindings",
     "query_bindings",
     "script_transforms",
+    "property_change_scripts",
     "properties"
   ],
   "node_type_counts": {
@@ -30,6 +31,7 @@
         "event_handler",
         "expression_binding",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },
@@ -73,6 +75,7 @@
         "custom_method",
         "event_handler",
         "message_handler",
+        "property_change_script",
         "transform"
       ]
     },

--- a/tests/unit/scripts/test_property_change_scripts.py
+++ b/tests/unit/scripts/test_property_change_scripts.py
@@ -1,0 +1,136 @@
+# pylint: disable=import-error
+"""
+Tests for modeling property-change (onChange) scripts as first-class script nodes.
+
+Regression coverage for issue #99: property-change scripts live under
+``propConfig.<property>.onChange.script`` (view-level) and
+``<component>.propConfig.<property>.onChange.script`` (component-level). The model
+builder previously only collected event-handler scripts under ``.events.`` paths,
+so these onChange bodies were never built into any script node. As a result,
+script-oriented rules such as ``PylintScriptRule`` silently skipped them.
+
+These tests assert that:
+  1. The builder emits a script node for each onChange script and registers it in
+     the generic ``model['scripts']`` collection so existing script visitors see it.
+  2. ``PylintScriptRule`` actually lints onChange script bodies.
+"""
+import json
+
+from fixtures.base_test import BaseRuleTest
+from fixtures.test_helpers import get_test_config, create_temp_view_file
+from ignition_lint.common.flatten_json import flatten_file
+from ignition_lint.model.builder import ViewModelBuilder
+from ignition_lint.model.node_types import ScriptNode
+
+
+def _build_view():
+	"""View exercising both view-level and component-level onChange scripts."""
+	return {
+		"custom": {},
+		"params": {},
+		"propConfig": {
+			# View-level custom property with an onChange handler.
+			"custom.total": {
+				"persistent": False,
+				"onChange": {
+					"enabled": True,
+					# References onChange parameters (valid) plus an undefined name (invalid).
+					"script": "\treturn previousValue.value + currentValue.value + undefinedTotal",
+				},
+			},
+		},
+		"props": {},
+		"root": {
+			"children": [{
+				"meta": {
+					"name": "Label"
+				},
+				"position": {
+					"height": 32,
+					"width": 200,
+					"x": 0,
+					"y": 0
+				},
+				"props": {
+					"text": "placeholder"
+				},
+				"propConfig": {
+					# Component-level custom property with an onChange handler.
+					"custom.flag": {
+						"persistent": False,
+						"onChange": {
+							"enabled": True,
+							"script": "\treturn currentValue.value and undefinedFlag",
+						},
+					},
+				},
+				"type": "ia.display.label",
+			}],
+			"meta": {
+				"name": "root"
+			},
+			"type": "ia.container.coord",
+		},
+	}
+
+
+class TestPropertyChangeScripts(BaseRuleTest):
+	"""Property-change (onChange) scripts must be modeled as script nodes."""
+
+	def _flatten(self):
+		view_file = create_temp_view_file(json.dumps(_build_view(), indent=2))
+		try:
+			return flatten_file(view_file)
+		finally:
+			view_file.unlink(missing_ok=True)
+
+	def test_builder_emits_script_nodes_for_onchange(self):
+		"""ViewModelBuilder should build a script node for each onChange handler."""
+		flattened = self._flatten()
+		model = ViewModelBuilder().build_model(flattened)
+
+		# Every onChange handler should surface in the generic scripts collection so
+		# existing script visitors (e.g. PylintScriptRule) pick it up.
+		onchange_scripts = [
+			node for node in model['scripts'] if isinstance(node, ScriptNode) and '.onChange' in node.path
+		]
+		onchange_paths = sorted(node.path for node in onchange_scripts)
+
+		self.assertIn(
+			"propConfig.custom.total.onChange", onchange_paths,
+			f"View-level onChange script not modeled. Got script paths: "
+			f"{sorted(n.path for n in model['scripts'])}"
+		)
+		self.assertTrue(
+			any(path.endswith("propConfig.custom.flag.onChange") for path in onchange_paths),
+			f"Component-level onChange script not modeled. Got script paths: "
+			f"{sorted(n.path for n in model['scripts'])}"
+		)
+
+	def test_pylint_rule_lints_onchange_script_bodies(self):
+		"""PylintScriptRule must report violations found inside onChange bodies."""
+		view_file = create_temp_view_file(json.dumps(_build_view(), indent=2))
+		try:
+			rule_config = get_test_config("PylintScriptRule")
+			results = self.run_lint_on_file(view_file, rule_config)
+		finally:
+			view_file.unlink(missing_ok=True)
+
+		# PylintScriptRule reports via custom-grouped output; undefined-variable
+		# (E0602) maps to the "error" severity by default.
+		formatted_errors = results.custom_formatted_errors.get("PylintScriptRule", "")
+
+		self.assertIn(
+			"E0602", formatted_errors,
+			f"Expected an undefined-variable (E0602) violation from an onChange body. "
+			f"Formatted errors: {formatted_errors!r}"
+		)
+		self.assertIn(
+			"onChange", formatted_errors, f"Expected the violation to reference an onChange script path. "
+			f"Formatted errors: {formatted_errors!r}"
+		)
+
+
+if __name__ == "__main__":
+	import unittest
+	unittest.main()


### PR DESCRIPTION
## Summary

Property-change (`onChange`) scripts defined under `propConfig.<property>.onChange.script` were never built into the object model. The `ViewModelBuilder` only collected event-handler scripts living under `.events.` paths, so these `onChange` bodies became no script node of any kind. As a result, script-oriented rules — notably `PylintScriptRule` — silently skipped them, and model/stats counts undercounted the scripts that actually exist in a view.

This PR models `onChange` scripts (both view-level, e.g. `propConfig.custom.total.onChange.script`, and component-level) as first-class script nodes so they flow through the existing script visitor pipeline and get linted like any other script.

This was surfaced while fixing #97 (PR #98) and called out there as out-of-scope, worthy of its own issue (#99).

---

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Feature (adds new functionality)
- [ ] Chore (cleanup, refactoring, or maintenance)
- [ ] Documentation update

**Impact:**

- [ ] Breaking change (would cause existing functionality not to work as expected)
- [x] Non-breaking change
- [ ] Requires documentation update

---

## Change Log

### Client-Facing
- **Added** — Property-change (`onChange`) scripts are now linted by `PylintScriptRule` (and any future script-body rule), and are counted in model statistics. Previously their bodies were silently skipped.

### Internal
- **Added** — `NodeType.PROPERTY_CHANGE_SCRIPT` and a `PropertyChangeScript` node type using the Perspective `onChange` signature `def valueChanged(self, previousValue, currentValue, origin, missedEvents):`.
- **Added** — `ViewModelBuilder._collect_property_change_scripts()` collects `propConfig.<prop>.onChange.script` (view- and component-scoped) into both the typed `property_change_scripts` collection and the generic `scripts` collection.
- **Added** — Regression tests in `tests/unit/scripts/test_property_change_scripts.py` covering builder modeling and `PylintScriptRule` linting of `onChange` bodies.
- **Changed** — `ScriptRule` routes the new node type via `visit_property_change_script`; `LintEngine` includes `property_change_scripts` in its lint and stats passes; `PylintScriptRule` fix path maps the new node type.
- **Changed** — Regenerated golden files (`tests/debug/cases/**`) for the new `property_change_scripts` model key; `ExpressionBindings` now models its `onChange` script.

---

## Target Version

v0.5.3

---

## Related Issues

Closes #99
Related: #97, #98

### Screenshots

N/A

## Review and Testing Notes

- Full suite green: `cd tests && python test_runner.py --run-all` (265 unit + 22 integration + 12 config).
- The golden-file changes are mechanical: every serialized model gains the empty `property_change_scripts` collection, and `ExpressionBindings` picks up one `onChange` script node. Regenerated with `python scripts/generate_debug_files.py`.
- To eyeball the behavior: the `onChange` body references `previousValue`/`currentValue` (valid params, not flagged) while an undefined name in the body is now correctly reported as `E0602`.
