### PR TITLE
fix: emit baseUrl-qualified links in docs llms.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Documentation site now publishes a working `llms.txt` / `llms-full.txt` index for LLM consumption. Links in `llms.txt` were previously root-rooted (e.g. `/getting-started/installation.md`) and 404'd under the `/ignition-lint/` GitHub Pages base path; they are now emitted as fully-qualified URLs via the plugin's `relativePaths: false` option. The search page is also excluded from the index. [33d2524]
+
 ## [0.5.2] - 2026-06-02
 
 ### Fixed

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -39,6 +39,16 @@ const config: Config = {
         depth: 2,
         content: {
           enableLlmsFullTxt: true,
+          // The site is served under baseUrl '/ignition-lint/'. With the
+          // default relativePaths: true, the plugin writes root-rooted links
+          // like '/getting-started/installation.md' that 404 on GitHub Pages.
+          // relativePaths: false makes it emit baseUrl-prefixed links
+          // ('/ignition-lint/getting-started/installation.md') that resolve.
+          relativePaths: false,
+          // The search page is not useful content for an LLM index.
+          // Patterns match the full route path, which includes the baseUrl
+          // (e.g. '/ignition-lint/search'), so use a baseUrl-independent glob.
+          excludeRoutes: ['**/search'],
         },
       },
     ],


### PR DESCRIPTION
# Pull Request

## Summary

The published documentation site generates an LLM-friendly `llms.txt` / `llms-full.txt` index via `@signalwire/docusaurus-plugin-llms-txt`. However, every link in `llms.txt` was written root-rooted (e.g. `/getting-started/installation.md`), ignoring the site's `baseUrl: '/ignition-lint/'`. As a result, any LLM or tool that discovered `llms.txt` and followed a link hit a **404** — the `.md` files actually live under `/ignition-lint/...`.

This sets the plugin's `relativePaths: false` option so links are emitted as fully-qualified URLs that resolve correctly, and excludes the (non-content) search page from the index. Verified against a local production build: all 30 index links are now fully-qualified, the referenced `.md` files exist, `llms-full.txt` is intact, and the search page is excluded.

---

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] Feature (adds new functionality)
- [ ] Chore (cleanup, refactoring, or maintenance)
- [ ] Documentation update

**Impact:**

- [ ] Breaking change (would cause existing functionality not to work as expected)
- [x] Non-breaking change
- [ ] Requires documentation update

---

## Change Log

### Client-Facing
- **Fixed** — `llms.txt` now links to fully-qualified, resolvable URLs (was 404ing under the `/ignition-lint/` GitHub Pages base path).
- **Changed** — The search page is excluded from the `llms.txt` index (it is not useful content for an LLM).

### Internal
- **Changed** — Set `relativePaths: false` and `excludeRoutes: ['**/search']` on `@signalwire/docusaurus-plugin-llms-txt` in `documentation/docusaurus.config.ts`, with explanatory comments covering the `baseUrl` gotcha.
- **Added** — `[Unreleased]` CHANGELOG entry documenting the fix (and the previously-unlogged llms.txt feature).

---

## Target Version

v0.5.3

---

## Related Issues

- Cross-repo rollout tracked in bw-design-group/internal.tools.solutions-department#29

### Screenshots

N/A

## Review and Testing Notes

Verified locally with a production build (`cd documentation && npm ci && npm run build`):
- `grep -oE '\]\(/[^)]+\)' build/llms.txt` → empty (no root-rooted links remain).
- All 30 index links are of the form `https://bw-design-group.github.io/ignition-lint/<path>.md`.
- Spot-checked that referenced `.md` files exist in `build/`; `build/llms-full.txt` present (~313 KB); `grep -c 'search' build/llms.txt` → 0.
- The change only takes effect once deployed from `main` (the `deploy-docs` workflow builds on push to `main`).
