### PR TITLE
fix: --files multi-file drop and scope-aware unused custom properties (v0.6.0)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,9 @@
   language: python
   types: [json]
   files: view\.json$
-  args: ['--config=.ignition-lint-precommit.json', '--files']
+  # No --files here: pre-commit appends the staged view.json paths as positional arguments
+  # (pass_filenames). --files is for glob mode (standalone runs), not an explicit file list.
+  args: ['--config=.ignition-lint-precommit.json']
   pass_filenames: true
   minimum_pre_commit_version: '2.9.0'
   additional_dependencies: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-05
+
+### Fixed
+- `--files` no longer silently drops the first file when two or more paths are passed (e.g. `--files A B C`, exactly how pre-commit invoked the bundled hook). `--files` is a single-value option, so argparse bound the first path to it and the rest to the variadic positional `filenames`; `collect_files` then treated the two sources as mutually exclusive (`if filenames: ... elif files: ...`) and discarded the path bound to `--files`. The two sources are now merged and de-duplicated, so every supplied file is linted.
+- `UnusedCustomPropertiesRule` no longer reports a false positive on a view-level custom property or parameter that is read via the bare `self.custom.X` / `self.params.X` idiom from a **view-scoped** script. Scope is now inferred from the flattened-JSON location: scripts on the view's own custom properties/params (top-level `propConfig.*`) or the view's event handlers (top-level `events.*`) run with `self` == the view, so a bare `self.custom.X` there is credited to `view.custom.X`. Component-scoped scripts (anything under `root.*`) keep the strict behavior — a bare `self.custom.X` refers to that component's own custom and does not credit a view-level property of the same name.
+
+### Changed
+- The space-separated multi-file form after `--files` (e.g. `--files A B C`) is deprecated. It is still linted, but ignition-lint now prints a deprecation warning pointing at the supported invocations: an explicit list as positional arguments, or a single comma-separated/glob value for `--files`.
+- The bundled pre-commit hook (`.pre-commit-hooks.yaml`) no longer appends `--files`; it relies on `pass_filenames` to pass staged files as positional arguments. The pre-commit, whitelist, and CLI docs are updated to document the two distinct file-selection modes (explicit positional list vs single `--files` glob) and to stop recommending the deprecated `--files`-last pattern.
+
 ## [0.5.3] - 2026-06-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,8 +283,9 @@ repos:
     rev: v1.0.0
     hooks:
       - id: ignition-lint
-        # Add whitelist argument to use project-specific whitelist
-        args: ['--config=.ignition-lint-precommit.json', '--whitelist=.whitelist.txt', '--files']
+        # Add whitelist argument to use project-specific whitelist.
+        # No --files: pre-commit passes staged files positionally (pass_filenames).
+        args: ['--config=.ignition-lint-precommit.json', '--whitelist=.whitelist.txt']
 ```
 
 **Important:** By default, ignition-lint does NOT use a whitelist unless you explicitly specify `--whitelist <path>`.
@@ -793,9 +794,9 @@ repos:
         name: ignition-lint
         entry: poetry run python -m ignition_lint
         language: system
+        # No --files: pre-commit passes staged files positionally (pass_filenames).
         args:
           - "--config=.ignition-lint.json"
-          - "--files"
         files: '.*view\.json$'
         types: [json]
         exclude: '^tests/.*|.*test.*\.json$'  # Exclude test files
@@ -818,7 +819,7 @@ repos:
     rev: v1.0.0
     hooks:
       - id: ignition-lint
-        args: ['--config=my-custom-config.json', '--files']
+        args: ['--config=my-custom-config.json']
         exclude: '^tests/.*|.*test.*\.json$'
 ```
 

--- a/documentation/docs/usage/cli.md
+++ b/documentation/docs/usage/cli.md
@@ -11,21 +11,55 @@ Complete reference for the `ign-lint` CLI. The CLI is the primary interface — 
 ## Synopsis
 
 ```bash
-ign-lint [<files>...] [--files <pattern>...] [options]
+ign-lint [FILE ...] [--files <pattern>] [options]
 ```
 
-## Common invocations
+## Selecting which files to lint
+
+There are **two distinct ways** to tell ignition-lint which files to check. Pick one — they
+are different input modes, not meant to be combined.
+
+### 1. Explicit file list (positional arguments)
+
+Pass concrete file paths directly. They are used verbatim — no globbing, no `view.json` name
+filtering. This is what pre-commit's `pass_filenames` appends, and what you want when you
+already know the exact files.
 
 ```bash
 # Single file
 ign-lint path/to/view.json
 
-# Glob pattern (quote it!)
+# Several explicit files
+ign-lint views/Home/view.json views/Login/view.json views/Admin/view.json
+```
+
+### 2. Glob mode (`--files`)
+
+`--files` takes a **single value**: one glob (or a comma-separated list of globs). The pattern
+is expanded by ignition-lint's own globber — not the shell — and results are filtered to
+`view.json`. Use this for standalone audits and CI full-repository scans.
+
+```bash
+# One glob (quote it so the shell doesn't expand it!)
 ign-lint --files "**/view.json"
 
-# Multiple patterns
-ign-lint --files "views/**/view.json" --files "components/**/view.json"
+# Multiple globs — comma-separated in ONE value
+ign-lint --files "views/**/view.json,components/**/view.json"
+```
 
+:::warning `--files` is not repeatable
+`--files` holds a single value, so repeating the flag does **not** accumulate — the last one
+wins. Write `--files "a/**/view.json,b/**/view.json"`, not
+`--files "a/**/view.json" --files "b/**/view.json"`. Likewise, passing multiple
+space-separated paths after `--files` (e.g. `--files A.json B.json`) is **deprecated**: the
+first path binds to `--files` and the rest to the positional list. ignition-lint still lints
+them all and prints a deprecation warning, but you should pass an explicit list as positional
+arguments (mode 1) instead.
+:::
+
+## Common invocations
+
+```bash
 # With config
 ign-lint --config rule_config.json --files "**/view.json"
 
@@ -39,7 +73,7 @@ ign-lint --config rule_config.json --files "**/view.json" --verbose
 
 | Flag | Description |
 | --- | --- |
-| `--files <pattern>` | Glob pattern of view files to lint. Repeatable. |
+| `--files <pattern>` | A **single** glob, or a comma-separated list of globs, expanded by ignition-lint's globber and filtered to `view.json` (default: `**/view.json`). **Not repeatable** — a second `--files` overrides the first. For an explicit set of files, pass them as positional arguments instead. See [Selecting which files to lint](#selecting-which-files-to-lint). |
 | `--config <path>` | Path to a `rule_config.json`. If omitted, every registered rule runs with defaults. |
 
 ### Whitelist

--- a/documentation/docs/usage/pre-commit.md
+++ b/documentation/docs/usage/pre-commit.md
@@ -28,6 +28,15 @@ pre-commit install
 
 The hook automatically runs on `view.json` files. It uses ignition-lint's bundled `.ignition-lint-precommit.json` (warnings-favored config) by default.
 
+:::note How files reach the hook
+Pre-commit passes the staged `view.json` paths to the hook as **positional arguments**
+(`pass_filenames: true`). Do **not** add `--files` to the hook's `args` — `--files` is for
+glob mode (a single pattern you run by hand), whereas pre-commit hands the hook an explicit
+list of files. Ending `args` with `--files` makes the first staged file bind to `--files` and
+is deprecated; ignition-lint will warn about it. Just omit `--files` and let `pass_filenames`
+do its job.
+:::
+
 **Pros:** zero setup, version-pinned via `rev:`, consistent across the team
 **Cons:** clones the full repo (~64 MB) into the pre-commit cache
 
@@ -45,7 +54,7 @@ repos:
         language: python
         types: [json]
         files: view\.json$
-        args: ['--config=rule_config.json', '--files']
+        args: ['--config=rule_config.json']
         pass_filenames: true
         additional_dependencies:
           - 'git+https://github.com/bw-design-group/ignition-lint@v0.2.4'
@@ -64,7 +73,7 @@ repos:
     rev: v0.2.4
     hooks:
       - id: ign-lint
-        args: ['--config=rule_config.json', '--files']
+        args: ['--config=rule_config.json']
 ```
 
 A common pattern is one config for pre-commit (warnings-favored, fast) and a separate one for CI (strict, full):
@@ -85,7 +94,7 @@ To allow commits with warnings (block only on errors):
 ```yaml
 hooks:
   - id: ign-lint
-    args: ['--config=rule_config.json', '--files', '--ignore-warnings']
+    args: ['--config=rule_config.json', '--ignore-warnings']
 ```
 
 This is useful when rolling out a new rule — set it to warning, let teams adapt, then promote to error.
@@ -100,7 +109,6 @@ hooks:
     args:
       - '--config=rule_config.json'
       - '--whitelist=.whitelist.txt'
-      - '--files'
 ```
 
 Generate the whitelist once and commit it:

--- a/documentation/docs/usage/whitelist.md
+++ b/documentation/docs/usage/whitelist.md
@@ -107,7 +107,7 @@ repos:
     rev: v0.2.4
     hooks:
       - id: ign-lint
-        args: ['--config=rule_config.json', '--whitelist=.whitelist.txt', '--files']
+        args: ['--config=rule_config.json', '--whitelist=.whitelist.txt']
 ```
 
 The full workflow:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ign-lint"
-version = "0.5.3"
+version = "0.6.0"
 description = "A linter for Ignition JSON files"
 authors = ["Alex Spyksma", "Eric Knorr"]
 license = "MIT"

--- a/src/ignition_lint/cli.py
+++ b/src/ignition_lint/cli.py
@@ -509,46 +509,62 @@ def collect_files(args, whitelist: set) -> tuple[List[Path], List[Path]]:
 	"""
 	files_to_process = []
 	files_ignored = []
+	seen: set = set()
 
-	# If filenames are provided directly (e.g., from pre-commit), use them
-	if args.filenames:
-		for filename in args.filenames:
+	def record(file_path: Path):
+		"""Whitelist-check and de-duplicate a resolved file, recording it appropriately."""
+		abs_path = file_path.resolve()
+		if abs_path in seen:
+			return
+		seen.add(abs_path)
+		if abs_path in whitelist:
+			files_ignored.append(file_path)
+			# Always print when a file is skipped (not just verbose mode)
+			print(f"🔒 Skipped (whitelisted): {file_path}")
+			return
+		files_to_process.append(file_path)
+
+	# Explicit file paths arrive via two argparse destinations that MUST be merged, not
+	# treated as either/or. When pre-commit invokes `--files PATH1 PATH2 PATH3`, argparse
+	# binds PATH1 to the single-value --files option and PATH2.. to the variadic `filenames`
+	# positional. The old `if filenames: ... elif files: ...` dispatch discarded PATH1
+	# whenever filenames was non-empty (i.e. for every multi-file commit). args.files is the
+	# default glob sentinel (None) only on a bare run; any other value is an explicit path
+	# argparse peeled off the --files list.
+	explicit_paths = list(args.filenames)
+	if args.filenames and args.files:
+		# `--files A B C`: argparse bound A to the single-value --files option and B.. to the
+		# positional. We still lint all of them, but the space-separated multi-file form is
+		# ambiguous - warn and point users at the supported invocations.
+		print(
+			"⚠️  Deprecation: '--files' takes a single value (a glob or comma-separated list), so "
+			"passing multiple space-separated paths after it is ambiguous and is deprecated.\n"
+			"   All paths are still linted for now. Prefer one of:\n"
+			"     • positional arguments:     ignition-lint FILE1 FILE2 ...\n"
+			"     • a single --files value:   --files \"FILE1,FILE2\"   (or a glob, e.g. --files \"**/view.json\")\n"
+			"   For pre-commit, drop the trailing '--files' from the hook args so staged files are "
+			"passed positionally."
+		)
+		explicit_paths.insert(0, args.files)
+
+	if explicit_paths:
+		for filename in explicit_paths:
 			file_path = Path(filename)
 			if not file_path.exists():
 				print(f"Warning: File {filename} does not exist")
 				continue
-
-			# Check if file is whitelisted
-			abs_path = file_path.resolve()
-			if abs_path in whitelist:
-				files_ignored.append(file_path)
-				# Always print when a file is skipped (not just verbose mode)
-				print(f"🔒 Skipped (whitelisted): {file_path}")
-				continue
-
-			files_to_process.append(file_path)
-
-	# Otherwise, use glob patterns
-	elif args.files:
-		for file_pattern in args.files.split(","):
+			record(file_path)
+	else:
+		# Glob mode: args.files is a comma-separated list of globs, or the default.
+		patterns = args.files if args.files else "**/view.json"
+		for file_pattern in patterns.split(","):
 			pattern = file_pattern.strip()
-			matching_files = glob.glob(pattern, recursive=True)
-
-			for file_path_str in matching_files:
+			for file_path_str in glob.glob(pattern, recursive=True):
 				file_path = Path(file_path_str)
 				# Only include view.json files specifically
 				if not file_path.exists() or file_path.name != "view.json":
 					continue
-
-				# Check if file is whitelisted
-				abs_path = file_path.resolve()
-				if abs_path in whitelist:
-					files_ignored.append(file_path)
-					# Always print when a file is skipped (not just verbose mode)
-					print(f"🔒 Skipped (whitelisted): {file_path}")
-					continue
-
-				files_to_process.append(file_path)
+				record(file_path)
 
 	# Print summary if verbose mode
 	if files_ignored and args.verbose:
@@ -1311,8 +1327,14 @@ def main():
 	)
 	parser.add_argument(
 		"--files",
-		default="**/view.json",
-		help="Comma-separated list of files or glob patterns to lint",
+		default=None,
+		help=(
+			"A SINGLE value: one file, a glob, or a comma-separated list of them "
+			"(e.g. --files \"**/view.json\" or --files \"a/view.json,b/view.json\"; "
+			"default: **/view.json). To lint several files, prefer positional arguments "
+			"(ignition-lint FILE1 FILE2 ...). Passing multiple space-separated paths after "
+			"--files is deprecated."
+		),
 	)
 	parser.add_argument(
 		"--verbose",

--- a/src/ignition_lint/rules/properties/unused_custom_properties.py
+++ b/src/ignition_lint/rules/properties/unused_custom_properties.py
@@ -236,8 +236,32 @@ class UnusedCustomPropertiesRule(LintingRule):
 				used_prop = handler(match)
 				self.used_properties.add(used_prop)
 
-	def _check_script_for_references(self, script: str):
-		"""Check a script string for custom property references."""
+	@staticmethod
+	def _is_view_scope_script_path(json_path: str) -> bool:
+		"""
+		Determine whether a script/value at the given flattened-JSON path runs at view scope.
+
+		In Perspective, `self` resolves to whatever owns the script. Scripts attached to the
+		view's own custom properties / parameters (top-level ``propConfig.*``) or the view's
+		event handlers (top-level ``events.*``) run with ``self`` == the view, so a bare
+		``self.custom.X`` there is identical to ``self.view.custom.X``. Everything under
+		``root.`` belongs to a component (the root container or a descendant), where ``self``
+		is that component - so a bare ``self.custom.X`` there must NOT credit a view-level
+		property (it would shadow/confuse a component's own custom of the same name).
+		"""
+		return json_path.startswith('propConfig.') or json_path.startswith('events.')
+
+	def _check_script_for_references(self, script: str, view_scope: bool = False):
+		"""
+		Check a script string for custom property references.
+
+		Args:
+			script: The script body to scan.
+			view_scope: True when the script provably runs with ``self`` == the view (see
+				_is_view_scope_script_path). In that case a bare ``self.custom.X`` /
+				``self.params.X`` also credits the view-level property, not just the
+				component wildcard.
+		"""
 		if not script:
 			return
 
@@ -248,8 +272,8 @@ class UnusedCustomPropertiesRule(LintingRule):
 		patterns = [
 			rf'self\.view\.custom\.{nested}',  # self.view.custom.propName
 			rf'self\.view\.params\.{nested}',  # self.view.params.paramName
-			rf'self\.custom\.{nested}',  # self.custom.propName (component)
-			rf'self\.params\.{nested}',  # self.params.propName (component)
+			rf'self\.custom\.{nested}',  # self.custom.propName (component, or view when view-scoped)
+			rf'self\.params\.{nested}',  # self.params.propName (component, or view when view-scoped)
 		]
 
 		for pattern in patterns:
@@ -262,8 +286,14 @@ class UnusedCustomPropertiesRule(LintingRule):
 					self.used_properties.add(f"view.params.{match}")
 				elif r'\.custom\.' in pattern:
 					self.used_properties.add(f"*.custom.{match}")
+					# A view-scoped self.custom.X is equivalent to self.view.custom.X.
+					if view_scope:
+						self.used_properties.add(f"view.custom.{match}")
 				elif r'\.params\.' in pattern:
 					self.used_properties.add(f"*.params.{match}")
+					# A view-scoped self.params.X is equivalent to self.view.params.X.
+					if view_scope:
+						self.used_properties.add(f"view.params.{match}")
 
 	def finalize(self):
 		"""Called after all nodes are visited - check for unused properties."""
@@ -377,9 +407,15 @@ class UnusedCustomPropertiesRule(LintingRule):
 				])
 
 		# Search through all values in the flattened JSON
-		for _, json_value in self.flattened_json.items():
+		for json_path, json_value in self.flattened_json.items():
 			if not isinstance(json_value, str):
 				continue
+
+			# The flattened key tells us whether a bare self.custom.X / self.params.X here runs
+			# at view scope (self == view) or component scope (self == component). See
+			# _is_view_scope_script_path. This is the one place that retains location, so scope
+			# decisions are made here rather than in the location-agnostic modeled-node visitors.
+			view_scope = self._is_view_scope_script_path(json_path)
 
 			# Check if any of our search patterns appear in this value
 			for pattern in search_patterns:
@@ -392,7 +428,7 @@ class UnusedCustomPropertiesRule(LintingRule):
 			# self.custom.X / self.params.X form) inside scripts that are not modeled as their
 			# own nodes - e.g. property-change (onChange) scripts - which would otherwise only
 			# be matched by the narrower substring patterns above.
-			self._check_script_for_references(json_value)
+			self._check_script_for_references(json_value, view_scope)
 			self._check_expression_for_references(json_value)
 
 	def _mark_property_used_from_pattern(self, pattern: str):

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -191,6 +191,61 @@ class TestCLIIntegration(BaseIntegrationTest):
 		except Exception as e:
 			self.fail(f"CLI is not executable: {e}")
 
+	def test_cli_files_processes_all_paths_passed_after_flag(self):
+		"""All paths after --files are processed (regression: the first one was dropped at N>=2).
+
+		Pre-commit invokes the hook as `--files PATH1 PATH2 ...`. argparse binds PATH1 to the
+		single-value --files option and the rest to the variadic `filenames` positional; the
+		old dispatch treated them as either/or and silently dropped PATH1. Parameterized over
+		N to guard both the N=1 (works) and N>=2 (previously broken) cases.
+		"""
+		minimal_view = '{ "root": { "type": "ia.container.flex", "props": {}, "children": [] } }'
+		for count in (1, 2, 3, 5):
+			with tempfile.TemporaryDirectory() as tmp:
+				tmp_path = Path(tmp)
+				view_paths = []
+				for i in range(count):
+					view_dir = tmp_path / f"view_{i}"
+					view_dir.mkdir()
+					view_file = view_dir / "view.json"
+					view_file.write_text(minimal_view, encoding="utf-8")
+					view_paths.append(str(view_file))
+
+				try:
+					# --stats-only collects/processes files without needing a rule config.
+					result = self._run_cli_command(["--stats-only", "--files", *view_paths])
+				except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+					self.skipTest(f"CLI test skipped: {e}")
+				except unittest.SkipTest:
+					raise
+
+				self.assertIn(
+					f"Files processed: {count}", result.stdout,
+					f"Expected all {count} files processed when passed via --files. "
+					f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+				)
+				# Every supplied view must appear in the output, not just N-1 of them. Match on the
+				# unique per-view directory name to avoid macOS /private symlink path differences.
+				for i in range(count):
+					self.assertIn(
+						f"view_{i}", result.stdout,
+						f"View dir view_{i} missing from output for N={count}. STDOUT: {result.stdout}"
+					)
+
+				# The ambiguous multi-path-after---files form is deprecated and must warn, but
+				# only when it actually occurs (N>=2 binds extra paths to the positional).
+				combined_output = result.stdout + result.stderr
+				if count >= 2:
+					self.assertIn(
+						"Deprecation", combined_output,
+						f"Expected a --files deprecation warning for N={count}. Output: {combined_output}"
+					)
+				else:
+					self.assertNotIn(
+						"Deprecation", combined_output,
+						f"Single --files path is unambiguous and must not warn. Output: {combined_output}"
+					)
+
 
 class TestCLIDiscovery(BaseIntegrationTest):
 	"""Test CLI discovery and basic functionality."""

--- a/tests/unit/test_unused_custom_properties.py
+++ b/tests/unit/test_unused_custom_properties.py
@@ -1172,3 +1172,161 @@ class TestUnusedCustomPropertiesRule(BaseRuleTest):  # pylint: disable=too-many-
 
 		# The nested child access in the onChange script credits the parent object property.
 		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_view_custom_referenced_via_self_custom_in_view_scope_onchange(self):
+		"""A view-level custom read via bare self.custom.X in a view-scoped onChange is used.
+
+		The onChange script lives on the view's own custom property (top-level propConfig.custom.*),
+		so at runtime `self` IS the view and `self.custom.supervisor` is identical to
+		`self.view.custom.supervisor`. The property must therefore be credited even though it is
+		never written with the longer self.view.custom form. Regression test for the
+		self.custom.X view-scope false positive.
+		"""
+		view_data = {
+			"custom": {
+				"supervisor": 0,
+				"devices": []
+			},
+			"propConfig": {
+				"custom.supervisor": {
+					"onChange": {
+						"enabled": None,
+						"script":
+							"\tfor i, device in enumerate(self.custom.devices):\n"
+							"\t\tdevice['supervisor'] = (i == self.custom.supervisor)"
+					},
+					"persistent": True
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# Both supervisor (read via self.custom.supervisor) and devices (read via self.custom.devices)
+		# are referenced from a view-scoped script, so neither should be flagged.
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_view_param_referenced_via_self_params_in_view_scope_script(self):
+		"""A view-level param read via bare self.params.X in a view-scoped script is used."""
+		view_data = {
+			"params": {
+				"threshold": 10
+			},
+			"custom": {
+				"derived": 0
+			},
+			"propConfig": {
+				"custom.derived": {
+					"binding": {
+						"type": "expr",
+						"config": {
+							"expression": "now()"
+						},
+						"transforms": [{
+							"type": "script",
+							"code":
+								"\tif self.params.threshold > 0:\n\t\treturn value\n\treturn None"
+						}]
+					}
+				},
+				"params.threshold": {
+					"paramDirection": "input",
+					"persistent": True
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# custom.derived is credited as a binding owner; view.params.threshold is read via
+		# self.params.threshold in that binding's view-scoped transform script.
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_view_custom_referenced_via_self_custom_in_view_event_handler(self):
+		"""A view-level custom read via self.custom.X in a top-level (view) event handler is used.
+
+		Top-level events.* are the view's own event handlers, where `self` is the view.
+		"""
+		view_data = {
+			"custom": {
+				"startupFlag": False
+			},
+			"events": {
+				"system": {
+					"onStartup": {
+						"config": {
+							"script": "\tif self.custom.startupFlag:\n\t\tpass"
+						},
+						"scope": "G",
+						"type": "script"
+					}
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# view.custom.startupFlag is read via self.custom.startupFlag in a view event handler.
+		self.assert_rule_errors(mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=0)
+
+	def test_truly_unused_view_custom_still_flagged_with_view_scope_fix(self):
+		"""Guard against over-correcting: a truly-unused view custom is still flagged.
+
+		One view custom (used) is read via self.custom in a view-scoped script; another (unused)
+		is never referenced anywhere. Only the unused one should be reported.
+		"""
+		view_data = {
+			"custom": {
+				"used": 1,
+				"trulyUnused": 2
+			},
+			"propConfig": {
+				"custom.used": {
+					"onChange": {
+						"enabled": None,
+						"script": "\tx = self.custom.used"
+					},
+					"persistent": True
+				}
+			},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+		mock_view_content = json.dumps(view_data, indent=2)
+		mock_view = create_temp_view_file(mock_view_content)
+
+		rule_config = get_test_config("UnusedCustomPropertiesRule")
+
+		# Only trulyUnused should be flagged; the view-scope fix must not blanket-credit customs.
+		self.assert_rule_errors(
+			mock_view, rule_config, "UnusedCustomPropertiesRule", expected_error_count=1,
+			error_patterns=["trulyUnused", "never referenced"]
+		)


### PR DESCRIPTION
## Summary

Fixes two bugs surfaced by a real-world view and tightens the related CLI/pre-commit documentation. Both fixes are independent, non-breaking, and covered by new regression tests.

1. **`--files` dropped the first file (N ≥ 2).** `--files` is a single-value option, so `--files A B C` (exactly how pre-commit invoked the bundled hook) bound `A` to `--files` and `B`/`C` to the variadic `filenames` positional. `collect_files` treated the two sources as mutually exclusive and silently discarded the path bound to `--files` — so every multi-file commit under-scanned, missing the alphabetically-first file with a green hook. The two sources are now merged and de-duplicated, so every supplied file is linted.

2. **`UnusedCustomPropertiesRule` false-positive on `self.custom.X`.** A view-level custom property/param read via the bare `self.custom.X` / `self.params.X` idiom was reported "defined but never referenced", because reference scanning was location-independent and never credited the view-level key from a bare reference. Crediting is now **scope-aware**: scripts on the view's own custom props/params (top-level `propConfig.*`) or the view's event handlers (top-level `events.*`) run with `self` == the view, so a bare `self.custom.X` there credits `view.custom.X`. Component-scoped scripts (anything under `root.*`) keep the strict behavior, so a component's own `self.custom.X` does not shadow a view-level property of the same name.

Also: the bundled pre-commit hook no longer appends `--files` (it relies on `pass_filenames`), the space-separated multi-file `--files` form is deprecated with a runtime warning, and the CLI/pre-commit/whitelist docs now document the two distinct file-selection modes (explicit positional list vs single `--files` glob).

---

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] Feature (adds new functionality)
- [ ] Chore (cleanup, refactoring, or maintenance)
- [x] Documentation update

**Impact:**

- [ ] Breaking change (would cause existing functionality not to work as expected)
- [x] Non-breaking change
- [x] Requires documentation update

---

## Change Log

### Client-Facing

- **Fixed:** `--files` no longer silently drops the first file when two or more paths are passed (e.g. `--files A B C`, as pre-commit invoked the bundled hook). All supplied files are now linted.
- **Fixed:** `UnusedCustomPropertiesRule` no longer false-flags a view-level custom property/parameter that is read via the bare `self.custom.X` / `self.params.X` idiom from a view-scoped script.
- **Changed:** The space-separated multi-file form after `--files` is deprecated; it still lints all files but now prints a deprecation warning pointing at the supported invocations (positional list, or a single comma/glob `--files` value).
- **Changed:** The bundled pre-commit hook (`.pre-commit-hooks.yaml`) no longer appends `--files`; it relies on `pass_filenames` to pass staged files positionally. CLI, pre-commit, and whitelist docs updated to document the two file-selection modes.

### Internal

- **Changed:** `collect_files` merges and de-duplicates the `filenames` positional and the `--files` value instead of treating them as mutually exclusive; `--files` default is now `None` to distinguish an explicit value from the default glob.
- **Changed:** `UnusedCustomPropertiesRule` infers script scope from the flattened-JSON key (`_is_view_scope_script_path`) and credits view-level keys for bare `self.` references only in view-scoped scripts.
- **Added:** Parametrized CLI integration test (N ∈ {1,2,3,5}) asserting all files are processed and the deprecation warning fires only for N ≥ 2; unit tests for view-scope crediting (onChange, binding transform, view event handler) plus a truly-unused guard.

---

## Target Version

0.6.0 (minor bump from v0.5.3 — distinct, non-breaking changes)

---

## Related Issues

N/A — reported via an internal bug report rather than a tracked issue.

### Screenshots

N/A

## Review and Testing Notes

- Full suite passes (`cd tests && python test_runner.py --run-all`); `pre-commit run --all-files` passes; pylint 9.81/10 (no new findings).
- **Bug 1 quick check:** `ign-lint --stats-only --files A/view.json B/view.json C/view.json` → `Files processed: 3` (was 2), with a deprecation warning. Positional form `ign-lint --stats-only A/view.json B/view.json C/view.json` → no warning.
- **Bug 2 differential:** a view-scoped `self.custom.X` read now clears the property; a component-scoped (`root.*`) bare `self.custom.X` still flags an otherwise-unreferenced view-level prop (preserved by `test_plain_self_custom_does_not_credit_view_level_scalar`).
- The PII test view used to confirm these was not committed; all tests use synthetic, PII-free fixtures.
