### PR TITLE
docs: point users to bw-design-group/ignition-lint

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "reviewers": [
+    "ia-eknorr"
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: poetry build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install Poetry

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,7 +12,7 @@ jobs:
   unittest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Ignition Lint Documentation
 
+> [!IMPORTANT]
+> **This project has moved.** Active development now happens at
+> **[bw-design-group/ignition-lint](https://github.com/bw-design-group/ignition-lint)**,
+> which is far ahead of this repository and actively maintained.
+>
+> - **pre-commit / CLI users:** point your config at `bw-design-group/ignition-lint`
+>   (or `pip install ign-lint`). The `ign-lint` package on PyPI is the maintained line.
+> - **GitHub Action users (`uses: ia-eknorr/ignition-lint@v2.x`):** bw does not ship a
+>   GitHub Action. Replace the action step with `pip install ign-lint` plus a CLI call
+>   (see the bw README). The `@v2.x` tags here remain resolvable but are frozen.
+>
+> This repository is archived and read-only as of June 2026.
+
 ## Overview
 
 Ignition Lint is a Python framework designed to analyze and lint Ignition Perspective view.json files. It provides a structured way to parse view files, build an object model representation, and apply customizable linting rules to ensure code quality and consistency across your Ignition projects.


### PR DESCRIPTION
## Why

`bw-design-group/ignition-lint` (a fork of this repo) is now **229 commits ahead** and is the actively maintained line of the project. This repo's recent history is dependency bumps only. Ahead of archiving this repository, this adds a prominent notice so existing and new users land on the maintained project.

## What

Adds an `> [!IMPORTANT]` banner to the top of the README with version-aware guidance:

- **CLI / pre-commit users** -> `bw-design-group/ignition-lint` (or `pip install ign-lint`, the maintained PyPI line).
- **GitHub Action users** (`uses: ia-eknorr/ignition-lint@v2.x`) -> bw ships no Action, so switch to `pip install ign-lint` + a CLI call. The `@v2.x` tags here stay resolvable but frozen.

No code or behavior changes.